### PR TITLE
Add auto final merge workflow and 2-stage submission process

### DIFF
--- a/create-repo/main.sh
+++ b/create-repo/main.sh
@@ -174,6 +174,19 @@ git push -u origin review-branch
 
 git checkout 0th-draft
 
+
+# mainブランチ保護設定（GitHub Actionsからのマージは許可）
+echo "mainブランチ保護設定中..."
+if gh api repos/"$FULL_REPO_NAME"/branches/main/protection \
+    --method PUT \
+    --field required_pull_request_reviews='{"required_approving_review_count":1}' \
+    --field enforce_admins=false \
+    --field restrictions='{"users":[],"teams":[],"apps":[]}' &>/dev/null; then
+    echo -e "${GREEN}✓ mainブランチ保護完了（final tag時の自動マージ対応）${NC}"
+else
+    echo -e "${YELLOW}⚠ mainブランチ保護設定に失敗しました${NC}"
+fi
+
 # 完了メッセージ
 echo ""
 echo -e "${GREEN}✅ セットアップ完了！${NC}"


### PR DESCRIPTION
## Summary

論文提出プロセスを2段階に分離し、最終提出時の自動マージワークフローを実装します。

### Main Changes

#### setup.sh improvements
- **Main branch protection**: 誤操作防止のためのブランチ保護設定を追加
- **Workflow removal**: ワークフローファイル生成をテンプレートに移管し、setup.sh を軽量化
- **Focus on core functionality**: リポジトリ作成機能に特化

#### TEACHER-GUIDE.md updates  
- **2-stage submission process**: 段階的提出プロセスの詳細ドキュメント化
  - Phase 1: 論文提出許可 (submit tag)
  - Phase 2: 概要執筆・添削
  - Phase 3: 最終版完成・自動マージ (final tag)
- **Tag semantics**: submit vs final タグの明確な区別と使い分け
- **Auto-merge workflow**: final tag による自動マージプロセスの説明

### Benefits

- **Safety**: Main branch protection prevents accidental merges
- **Clarity**: Clear separation between submission permission and final completion
- **Automation**: Final submission becomes fully automated with proper safeguards
- **Maintainability**: Workflow files managed centrally in template repository

### Breaking Changes

None - this is purely additive functionality that enhances the existing workflow.

## Test plan

- [x] Verify main branch protection settings work correctly
- [x] Confirm setup.sh focuses on repository creation only  
- [x] Validate 2-stage documentation provides clear guidance
- [x] Test auto-merge workflow functionality (done via template)