### PR TITLE
Fix weekly report setup script execution error

### DIFF
--- a/create-repo/Dockerfile-wr
+++ b/create-repo/Dockerfile-wr
@@ -17,12 +17,12 @@ RUN type -p curl >/dev/null || (apt update && apt install curl -y) \
     && apt update \
     && apt install gh -y
 
+# 作業ディレクトリ
+WORKDIR /workspace
+
 # セットアップスクリプトをコピー
 COPY main-wr.sh ./
 RUN chmod +x main-wr.sh
-
-# 作業ディレクトリ
-WORKDIR /workspace
 
 # Docker環境では手動ブラウザアクセスを前提
 ENV DOCKER_ENV=true


### PR DESCRIPTION
## Summary
- Fix main-wr.sh not found error in Docker container
- Set WORKDIR before copying script to ensure correct path

## Problem
The Dockerfile-wr was copying main-wr.sh to root directory then changing WORKDIR to /workspace, causing the script to not be found at runtime.

## Solution  
Reorder Dockerfile commands to set WORKDIR first, then copy main-wr.sh to the correct location.

## Test plan
- [ ] Run setup-wr.sh script
- [ ] Verify main-wr.sh is found and executed correctly
- [ ] Confirm weekly report repository is created successfully

🤖 Generated with [Claude Code](https://claude.ai/code)