### PR TITLE
Remove .claude/settings.local.json from repository tracking

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,8 +1,0 @@
-{
-  "permissions": {
-    "allow": [
-      "Bash(find:*)"
-    ],
-    "deny": []
-  }
-}

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@ Thumbs.db
 # Temporary files
 *.tmp
 *.temp
+# Claude Code local settings
+.claude/settings.local.json


### PR DESCRIPTION
## Summary

Remove `.claude/settings.local.json` from git tracking and add to .gitignore to prevent future tracking.

## Changes
- **Remove from git**: Stop tracking `.claude/settings.local.json`
- **.gitignore update**: Add `.claude/settings.local.json` to prevent future commits
- **Local file preserved**: Keep local file for development purposes

## Rationale
- Local settings should not be shared in template repositories
- Users should configure Claude Code permissions individually
- Prevents accidental commit of personal development settings

## Technical Details
- Used `git rm --cached` to remove from tracking without deleting local file
- Added specific ignore pattern for Claude Code local settings
- Template users will need to configure their own `.claude/settings.local.json` if needed

## Note
This PR is based on the `improve-docker-build-output` branch as it was the current working branch.