### PR TITLE
Fix JST date boundary calculation bug

### DIFF
--- a/create-repo/main.sh
+++ b/create-repo/main.sh
@@ -336,13 +336,11 @@ create_protection_request_issue() {
     
     local jst_hour=$(( (utc_hour + 9) % 24 ))
     
-    # 日付が変わる場合の処理
+    # 日付が変わる場合の処理（UTC 15:00以降はJST翌日）
     if [ $((utc_hour + 9)) -ge 24 ]; then
-        # 翌日になる場合、日付を1日進める
-        # シンプルな実装：月末や年末の処理は date コマンドに任せる
-        local next_day_seconds=$(( $(date -u +%s) + 86400 ))
-        # Alpine Linux互換の方法で翌日を取得
-        local created_date=$(TZ=UTC-9 date -u +'%Y-%m-%d')
+        # 翌日になる場合、エポック時間を使って正確に計算
+        local tomorrow_epoch=$(( $(date -u +%s) + 86400 ))
+        local created_date=$(date -u -d "@$tomorrow_epoch" +'%Y-%m-%d')
     else
         local created_date="${utc_year}-${utc_month}-${utc_day}"
     fi


### PR DESCRIPTION
## Overview
Fix critical JST date boundary calculation bug caused by non-functional TZ environment variable in Docker environment

## 🐛 Discovered Issues

### 1. TZ=UTC-9 Not Working in Docker
```bash
# Actual behavior in Docker Ubuntu environment
TZ=UTC-9 date -u +'%Y-%m-%d'
# Expected: JST date (UTC+9)
# Actual: UTC date unchanged (TZ setting ignored)
```

### 2. Critical Date Boundary Bug
```bash
# Case: UTC 16:00 = JST next day 01:00
# Expected: 2025-06-22 (next day)
# Actual: 2025-06-21 (same day) ← BUG
```

## 🔧 Fix Details

### Before (Buggy Implementation)
```bash
if [ $((utc_hour + 9)) -ge 24 ]; then
    # TZ=UTC-9 doesn't work, returns UTC date
    local created_date=$(TZ=UTC-9 date -u +'%Y-%m-%d')  # ← BUG
else
    local created_date="${utc_year}-${utc_month}-${utc_day}"
fi
```

### After (Fixed Implementation)
```bash
if [ $((utc_hour + 9)) -ge 24 ]; then
    # Accurate next-day calculation using epoch time
    local tomorrow_epoch=$(( $(date -u +%s) + 86400 ))
    local created_date=$(date -u -d "@$tomorrow_epoch" +'%Y-%m-%d')
else
    local created_date="${utc_year}-${utc_month}-${utc_day}"
fi
```

## ✅ Test Results

### Before Fix
```bash
UTC 16:00 (JST 01:00 next day) → 2025-06-21 (wrong same day)
```

### After Fix
```bash
UTC 16:00 (JST 01:00 next day) → 2025-06-22 (correct next day)
```

## 🎯 Impact

### Fixed Issues
- Issue creation during JST 00:00-08:59 (UTC 15:00-23:59)
- Resolves incorrect date recording in Issues

### Target Environment
- Ubuntu Docker containers (GNU date)
- No cross-platform considerations needed

## 🔍 Root Cause
In Docker environments, TZ environment variables do not affect `date -u` command. PR #39 assumed "TZ works fine" but TZ itself was **not functioning**.

## Related
- Fixes actual bug discovered during implementation review
- Related to PR #39 improvements
- Addresses Issue #40 concerns (but for different reasons than initially thought)

Now JST time/date display is completely independent of TZ environment variables.