### PR TITLE
Fix ai-reviewer.yml: Remove unsupported parameter

### DIFF
--- a/.github/workflows/ai-reviewer.yml
+++ b/.github/workflows/ai-reviewer.yml
@@ -28,4 +28,3 @@ jobs:
           LANGUAGE: "Japanese"
           EXCLUDE_PATHS: >-
             _build/**,deps/**,cover/**,log/**,data/**,*.tmp,*.temp
-          USE_SINGLE_COMMENT_REVIEW: "true"


### PR DESCRIPTION
## Summary
ai-reviewer.ymlワークフローでサポートされていないパラメータによる警告を修正

## Problem
Nasubikun/ai-reviewer@v1アクションで`USE_SINGLE_COMMENT_REVIEW`パラメータがサポートされておらず、GitHub Actionsで警告が発生していました：

```
Unexpected input(s) 'USE_SINGLE_COMMENT_REVIEW', valid inputs are ['GEMINI_API_KEY', 'GITHUB_TOKEN', 'MODEL_CODE', 'LANGUAGE', 'EXCLUDE_PATHS']
```

## Solution
### 変更内容
- `USE_SINGLE_COMMENT_REVIEW: "true"`パラメータを削除
- サポートされているパラメータのみ使用

### サポートされているパラメータ
- `GEMINI_API_KEY` ✅
- `GITHUB_TOKEN` ✅  
- `MODEL_CODE` (未使用)
- `LANGUAGE` ✅
- `EXCLUDE_PATHS` ✅

### 影響
- ✅ GitHub Actions警告の解消
- ✅ ワークフロー実行の正常化
- ✅ 機能への影響なし（レビュー機能は継続して動作）

## Test Results
- `yamllint`: ✅ パス
- `actionlint`: ✅ パス

## Related Issue
- GitHub Actions実行ID: 15803889160での警告解消
- 今後のPRでのAIレビュー機能正常化

この修正により、AIレビューワークフローが警告なしで正常に動作するようになります。