### PR TITLE
Fix cleanup_duplicates function for GitHub Actions compatibility

### DIFF
--- a/scripts/extract-student-info-from-issues.sh
+++ b/scripts/extract-student-info-from-issues.sh
@@ -182,23 +182,29 @@ cleanup_duplicates() {
     log "重複除去を実行中..."
     
     # 各ファイルの重複を除去
-    find data/students -name "*.txt" -type f | while read -r file; do
+    while IFS= read -r -d '' file; do
         if [ -f "$file" ] && [ -s "$file" ]; then
-            sort -u "$file" -o "$file"
+            if ! sort -u "$file" -o "$file"; then
+                warn "重複除去失敗: $file"
+            fi
         fi
-    done
+    done < <(find data/students -name "*.txt" -type f -print0)
     
     # protection-statusファイルの重複除去
     for file in data/protection-status/*.txt; do
-        if [ -f "$file" ] && [ -s "$file" ]; then
-            sort -u "$file" -o "$file"
+        if [ -f "$file" ] && [ -e "$file" ] && [ -s "$file" ]; then
+            if ! sort -u "$file" -o "$file"; then
+                warn "重複除去失敗: $file"
+            fi
         fi
     done
     
     # repositoriesファイルの重複除去
     for file in data/repositories/*.txt; do
-        if [ -f "$file" ] && [ -s "$file" ]; then
-            sort -u "$file" -o "$file"
+        if [ -f "$file" ] && [ -e "$file" ] && [ -s "$file" ]; then
+            if ! sort -u "$file" -o "$file"; then
+                warn "重複除去失敗: $file"
+            fi
         fi
     done
     

--- a/scripts/extract-student-info-from-issues.sh
+++ b/scripts/extract-student-info-from-issues.sh
@@ -105,7 +105,7 @@ extract_from_issues() {
     local processed=0
     while read -r issue; do
         if process_single_issue "$issue"; then
-            ((processed++))
+            processed=$((processed + 1))
         fi
     done < <(jq -c '.[]' "$filtered_issues")
     
@@ -174,6 +174,14 @@ process_single_issue() {
     fi
     
     log "  Issue #$issue_number の情報をレジストリに記録しました"
+    
+    # デバッグ用: 各ステップ後の状態を確認
+    if [ "${DEBUG:-0}" = "1" ]; then
+        log "  [DEBUG] data/students/$year/$type.txt に追加完了"
+        log "  [DEBUG] pending-protection.txt に追加完了"
+        log "  [DEBUG] active.txt に追加完了"
+    fi
+    
     return 0
 }
 


### PR DESCRIPTION
## Summary  
• Fixed cleanup_duplicates function causing workflow failures
• Resolved set -e pipefail compatibility issues in GitHub Actions
• Fixed arithmetic operation compatibility with strict mode

## Problems Fixed
1. cleanup_duplicates function using problematic while-read pipeline with set -e
2. ((processed++)) operation failing under strict mode in GitHub Actions

## Solutions
• Replaced `find | while read` with process substitution `< <(find -print0)`
• Changed `((processed++))` to `processed=$((processed + 1))`
• Added explicit error handling for sort operations  
• Used -e flag checks to prevent non-existent file errors
• Added debug logging for better troubleshooting

## Test plan
- [x] Tested locally - script completes successfully
- [x] Tested with act - workflow passes extract stage
- [ ] Verify GitHub Actions workflow passes completely
- [ ] Confirm all student data is processed correctly