### PR TITLE
Temporarily disable scheduled workflow execution

### DIFF
--- a/.github/workflows/student-repo-management.yml
+++ b/.github/workflows/student-repo-management.yml
@@ -1,9 +1,9 @@
 ---
 name: Student Repository Management
 "on":
-  schedule:
-    # 2時間ごとに実行
-    - cron: '0 */2 * * *'
+  # schedule:
+  #   # 2時間ごとに実行
+  #   - cron: '0 */2 * * *'
   workflow_dispatch:
     inputs:
       force_update:


### PR DESCRIPTION
## Summary
• Temporarily disable scheduled workflow execution
• Keep manual workflow_dispatch for debugging
• Prevent unnecessary failed runs while debugging issues

## Reason
The workflow is still experiencing failures after recent fixes. To avoid noise from scheduled runs every 2 hours, we're temporarily disabling the schedule trigger until all issues are resolved.

## Changes
- Comment out `schedule` trigger in workflow YAML
- Manual runs via workflow_dispatch remain available

## Next Steps
1. Debug remaining workflow issues with manual runs
2. Fix all problems
3. Re-enable schedule trigger once workflow is stable