### PR TITLE
Fix handling of empty or missing pending-protection.txt file

### DIFF
--- a/scripts/bulk-setup-protection.sh
+++ b/scripts/bulk-setup-protection.sh
@@ -138,8 +138,9 @@ main() {
     log "Starting bulk branch protection setup..."
     
     if [ ! -f "$PENDING_FILE" ]; then
-        error "Pending file not found: $PENDING_FILE"
-        exit 1
+        log "Pending file not found: $PENDING_FILE"
+        log "No repositories to process. Exiting normally."
+        exit 0
     fi
     
     # GitHub CLI認証確認
@@ -152,10 +153,16 @@ main() {
     local success_count=0
     local failed_students=""
     
+    # ファイルが空かチェック
+    if [ ! -s "$PENDING_FILE" ]; then
+        log "Pending file is empty. No repositories to process."
+        exit 0
+    fi
+    
     # 処理対象のリポジトリをカウント
     while read -r repo_name; do
         if [ -n "$repo_name" ] && [[ "$repo_name" =~ ^k[0-9]{2}[rg][sjk][0-9]+-[a-z]+$ ]]; then
-            ((total_count++))
+            total_count=$((total_count + 1))
         fi
     done < "$PENDING_FILE"
     


### PR DESCRIPTION
## Summary
• Fix workflow failure when no pending repositories exist
• Handle empty or missing pending-protection.txt gracefully
• Exit normally instead of with error when nothing to process

## Problem
Workflow was failing with:
```
Pending file not found: /home/runner/work/.../data/protection-status/pending-protection.txt
Process completed with exit code 1
```

This happens when:
- All issues have been processed
- No new repositories need protection setup
- The pending file is empty or doesn't exist

## Solution
• Check if file exists → log and exit 0 (not error)
• Check if file is empty → log and exit 0 
• Fix `((total_count++))` to work with strict mode
• These are normal conditions, not errors

## Test plan
- [x] Script handles missing file gracefully
- [x] Script handles empty file gracefully
- [ ] Workflow completes successfully when no pending repos