### PR TITLE
Fix GitHub CLI authentication and script paths in workflow

### DIFF
--- a/.github/workflows/student-repo-management.yml
+++ b/.github/workflows/student-repo-management.yml
@@ -25,6 +25,8 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup GitHub CLI
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           type -p gh >/dev/null || (
             curl -fsSL \
@@ -37,6 +39,10 @@ jobs:
             sudo apt update
             sudo apt install gh
           )
+          # GitHub CLI認証確認
+          echo "Configuring GitHub CLI authentication..."
+          echo "$GH_TOKEN" | gh auth login --with-token
+          gh auth status
 
       - name: Extract student info from issues
         env:


### PR DESCRIPTION
## Summary
- GitHub CLI認証エラーを修正: `gh auth login --with-token` で明示的認証
- 認証状態の確認を追加
- ワークフロー内でのスクリプト実行問題を解決

## 修正内容
- Setup GitHub CLIステップで`GH_TOKEN`を使用した認証設定
- `gh auth status`で認証確認
- スクリプト実行前の認証確保

## Test plan
- issue作成時の自動ブランチ保護設定テスト
- k18rs914-sotsuronリポジトリでの動作確認
- 認証エラーの解消確認