### PR TITLE
Simplify GitHub CLI authentication in workflow

### DIFF
--- a/.github/workflows/student-repo-management.yml
+++ b/.github/workflows/student-repo-management.yml
@@ -39,9 +39,8 @@ jobs:
             sudo apt update
             sudo apt install gh
           )
-          # GitHub CLI認証確認
-          echo "Configuring GitHub CLI authentication..."
-          echo "$GH_TOKEN" | gh auth login --with-token
+          # GitHub CLI認証確認（GH_TOKENが自動使用される）
+          echo "Verifying GitHub CLI authentication..."
           gh auth status
 
       - name: Extract student info from issues

--- a/.github/workflows/student-repo-management.yml
+++ b/.github/workflows/student-repo-management.yml
@@ -43,7 +43,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           echo "📊 未処理Issueから学生情報を抽出中..."
-          ./scripts/extract-student-info-from-issues.sh
+          bash scripts/extract-student-info-from-issues.sh
 
       - name: Setup branch protection
         env:
@@ -55,7 +55,7 @@ jobs:
             student_id=$(echo "${{ github.event.issue.body }}" | grep -oE 'k[0-9]{2}[rg][sjk][0-9]+' | head -1 || true)
             if [ -n "$student_id" ]; then
               echo "🎯 Issue作成による即座のブランチ保護設定: $student_id"
-              if ./scripts/setup-branch-protection.sh "$student_id"; then
+              if bash scripts/setup-branch-protection.sh "$student_id"; then
                 echo "✅ ブランチ保護設定完了: $student_id"
                 echo "PROTECTION_SUCCESS=true" >> $GITHUB_ENV
                 echo "STUDENT_ID=$student_id" >> $GITHUB_ENV
@@ -71,7 +71,7 @@ jobs:
           else
             # 手動実行時：一括処理
             echo "📋 一括ブランチ保護設定を実行中..."
-            ./scripts/bulk-setup-protection.sh
+            bash scripts/bulk-setup-protection.sh
             echo "PROTECTION_SUCCESS=true" >> $GITHUB_ENV
           fi
 
@@ -80,7 +80,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           echo "📝 学生レジストリを更新中..."
-          ./scripts/update-student-registry.sh
+          bash scripts/update-student-registry.sh
 
       - name: Commit registry updates
         run: |


### PR DESCRIPTION
## Summary
GitHub CLI認証を簡略化して失敗を解決

## 修正内容
- `gh auth login --with-token` を削除（GH_TOKENが自動使用されるため）
- 認証状態確認のみ残す
- ワークフロー認証エラーを解消

## 問題
前回の修正で`GH_TOKEN`環境変数が既に設定されている状態で`gh auth login --with-token`を実行していたため、「The value of the GH_TOKEN environment variable is being used for authentication」エラーで失敗

## Test plan
- issue作成時の自動実行テスト
- k18rs914-sotsuronでの動作確認