### PR TITLE
Fix GitHub Actions authentication in setup-branch-protection.sh

### DIFF
--- a/.github/workflows/student-repo-management.yml
+++ b/.github/workflows/student-repo-management.yml
@@ -39,9 +39,8 @@ jobs:
             sudo apt update
             sudo apt install gh
           )
-          # GitHub CLI認証確認
-          echo "Configuring GitHub CLI authentication..."
-          echo "$GH_TOKEN" | gh auth login --with-token
+          # GitHub CLI認証確認（GH_TOKENが自動使用される）
+          echo "Verifying GitHub CLI authentication..."
           gh auth status
 
       - name: Extract student info from issues

--- a/.github/workflows/student-repo-management.yml
+++ b/.github/workflows/student-repo-management.yml
@@ -43,7 +43,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           echo "📊 未処理Issueから学生情報を抽出中..."
-          ./scripts/extract-student-info-from-issues.sh
+          bash scripts/extract-student-info-from-issues.sh
 
       - name: Setup branch protection
         env:
@@ -55,7 +55,7 @@ jobs:
             student_id=$(echo "${{ github.event.issue.body }}" | grep -oE 'k[0-9]{2}[rg][sjk][0-9]+' | head -1 || true)
             if [ -n "$student_id" ]; then
               echo "🎯 Issue作成による即座のブランチ保護設定: $student_id"
-              if ./scripts/setup-branch-protection.sh "$student_id"; then
+              if bash scripts/setup-branch-protection.sh "$student_id"; then
                 echo "✅ ブランチ保護設定完了: $student_id"
                 echo "PROTECTION_SUCCESS=true" >> $GITHUB_ENV
                 echo "STUDENT_ID=$student_id" >> $GITHUB_ENV
@@ -71,7 +71,7 @@ jobs:
           else
             # 手動実行時：一括処理
             echo "📋 一括ブランチ保護設定を実行中..."
-            ./scripts/bulk-setup-protection.sh
+            bash scripts/bulk-setup-protection.sh
             echo "PROTECTION_SUCCESS=true" >> $GITHUB_ENV
           fi
 
@@ -80,7 +80,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           echo "📝 学生レジストリを更新中..."
-          ./scripts/update-student-registry.sh
+          bash scripts/update-student-registry.sh
 
       - name: Commit registry updates
         run: |


### PR DESCRIPTION
## Summary
setup-branch-protection.shでGitHub Actions環境での認証エラーを解決

## 修正内容
- **認証チェック改善**: `gh api user` → `gh auth status` に変更
- **環境検出**: `GITHUB_ACTIONS`環境変数でGitHub Actions環境を検出
- **権限チェック最適化**: GitHub Actions環境では権限チェックをスキップ（GITHUB_TOKENで十分な権限を保証）
- **両環境対応**: ローカルとGitHub Actions両方で動作

## 問題解決
GitHub Actions環境で`github-actions[bot]`アカウントが`gh api user`で認証エラーになる問題を解決

## Test plan
- 新しいissue作成によるワークフロー自動実行テスト
- GitHub Actions環境でのブランチ保護設定確認
- ローカル環境での動作確認（既存機能維持）