### PR TITLE
Fix student ID extraction from completed-protection.txt

### DIFF
--- a/.github/workflows/student-repo-management.yml
+++ b/.github/workflows/student-repo-management.yml
@@ -148,13 +148,23 @@ jobs:
             # 最新の学生情報を取得
             completed_file="data/protection-status/completed-protection.txt"
             if [[ -f "$completed_file" ]]; then
-              # 最新の完了エントリを取得
-              latest_student=$(tail -n 1 "$completed_file" 2>/dev/null || \
-                              echo "")
+              # 最新の完了エントリから学生IDを抽出
+              latest_entry=$(tail -n 1 "$completed_file" 2>/dev/null || \
+                            echo "")
+              
+              # 学生IDを抽出 (例: "k02jk059-sotsuron # Completed: ... Student: k02jk059" から "k02jk059")
+              if [[ "$latest_entry" =~ Student:\ ([k][0-9]{2}(rs|jk|gjk)[0-9]+) ]]; then
+                latest_student="${BASH_REMATCH[1]}"
+              else
+                # フォールバック: リポジトリ名から学生IDを抽出
+                latest_student=$(echo "$latest_entry" | \
+                               grep -oE '^k[0-9]{2}(rs|jk|gjk)[0-9]+' || echo "")
+              fi
 
               if [[ -n "$latest_student" ]]; then
-                echo "🎯 Processing latest completed student:" \
+                echo "🎯 Processing latest completed student ID:" \
                      "$latest_student"
+                echo "   From entry: $latest_entry"
 
                 # 複数のリポジトリタイプを処理
                 for repo_type in sotsuron ise-report1 ise-report2 wr; do


### PR DESCRIPTION
## Summary
- thesis-student-registryの更新時に学生ID抽出が正しく動作しない問題を修正
- completed-protection.txtから行全体ではなく学生IDのみを正しく抽出するように改善
- フォールバック機能と詳細ログを追加

## Problem
ワークフローがthesis-student-registryを更新する際、latest_studentに以下の値が設定されていた：
```
k02jk059-sotsuron # Completed: 2025-06-24 Student: k02jk059
```

これにより、学生ID（k02jk059）ではなく行全体が抽出され、レジストリ更新が失敗していた。

## Solution
- 正規表現を使用して"Student: k##xxx###"形式から学生IDを抽出
- リポジトリ名からの抽出をフォールバックとして追加
- デバッグ出力を追加して抽出過程を可視化

## Test plan
- [ ] 既存のcompleted-protection.txtエントリで正しく動作することを確認
- [ ] 新しいリポジトリ作成でthesis-student-registry更新が成功することを確認
- [ ] ワークフローログで学生ID抽出が正しく行われることを確認