### PR TITLE
Fix: Improve workflow for weekly report repositories

### DIFF
--- a/.github/workflows/student-repo-management.yml
+++ b/.github/workflows/student-repo-management.yml
@@ -80,14 +80,27 @@ jobs:
           echo "Token type: $TOKEN_TYPE"
 
           if [ "${{ github.event_name }}" = "issues" ]; then
-            # Issue作成時：該当学生のブランチ保護を即座に設定
+            # Issue作成時：該当学生の処理を実行
             student_id=$(echo "$ISSUE_BODY" | \
                          grep -oE 'k[0-9]{2}(rs|jk|gjk)[0-9]+' | \
                          head -1 || true)
-            echo "Extracted student ID from issue:" \
-                 "${student_id:-'(none found)'}"
-            if [ -n "$student_id" ]; then
-              echo "🎯 Issue作成による即座のブランチ保護設定: $student_id"
+            
+            # リポジトリタイプの判定
+            repo_type=""
+            issue_title="${{ github.event.issue.title }}"
+            if [[ "$issue_title" == *"-wr"* ]]; then
+              repo_type="wr"
+            elif [[ "$issue_title" == *"-sotsuron"* ]]; then
+              repo_type="sotsuron"
+            elif [[ "$issue_title" == *"-thesis"* ]]; then
+              repo_type="thesis"
+            fi
+
+            echo "Extracted student ID from issue: ${student_id:-'(none found)'}"
+            echo "Detected repository type: ${repo_type:-'(unknown)'}"
+            
+            if [ -n "$student_id" ] && [ -n "$repo_type" ]; then
+              echo "🎯 Issue作成による処理開始: $student_id ($repo_type)"
 
               # 権限チェック：GITHUB_TOKENでは制限される可能性を警告
               if [ "$TOKEN_TYPE" = "GITHUB_DEFAULT" ]; then
@@ -95,20 +108,31 @@ jobs:
                 echo "他リポジトリへのアクセスに制限がある可能性があります"
               fi
 
-              # エラーハンドリング強化
-              if bash scripts/setup-branch-protection.sh \
-                      "$student_id" 2>&1; then
-                echo "✅ ブランチ保護設定完了: $student_id"
+              # リポジトリタイプ別の処理
+              if [ "$repo_type" = "wr" ]; then
+                echo "📝 週報リポジトリ: ブランチ保護をスキップして登録のみ実行"
                 echo "PROTECTION_SUCCESS=true" >> "$GITHUB_ENV"
                 echo "STUDENT_ID=$student_id" >> "$GITHUB_ENV"
+                echo "REPO_TYPE=$repo_type" >> "$GITHUB_ENV"
+                echo "SKIP_PROTECTION=true" >> "$GITHUB_ENV"
               else
-                exit_code=$?
-                echo "❌ ブランチ保護設定失敗: $student_id" \
-                     "(exit code: $exit_code)"
-                echo "トークンタイプ: $TOKEN_TYPE"
-                echo "使用中トークン: ${GH_TOKEN:0:8}..."
-                echo "PROTECTION_SUCCESS=false" >> "$GITHUB_ENV"
-                echo "ERROR_CODE=$exit_code" >> "$GITHUB_ENV"
+                echo "🔒 論文リポジトリ: ブランチ保護設定を実行"
+                # エラーハンドリング強化
+                if bash scripts/setup-branch-protection.sh \
+                        "$student_id" 2>&1; then
+                  echo "✅ ブランチ保護設定完了: $student_id"
+                  echo "PROTECTION_SUCCESS=true" >> "$GITHUB_ENV"
+                  echo "STUDENT_ID=$student_id" >> "$GITHUB_ENV"
+                  echo "REPO_TYPE=$repo_type" >> "$GITHUB_ENV"
+                else
+                  exit_code=$?
+                  echo "❌ ブランチ保護設定失敗: $student_id" \
+                       "(exit code: $exit_code)"
+                  echo "トークンタイプ: $TOKEN_TYPE"
+                  echo "使用中トークン: ${GH_TOKEN:0:8}..."
+                  echo "PROTECTION_SUCCESS=false" >> "$GITHUB_ENV"
+                  echo "ERROR_CODE=$exit_code" >> "$GITHUB_ENV"
+                fi
               fi
             else
               echo "⚠️ 学生IDを抽出できませんでした"
@@ -147,63 +171,46 @@ jobs:
           if [[ -d "thesis-student-registry" ]]; then
             echo "✅ thesis-student-registry found"
 
-            # 最新の学生情報を取得
-            completed_file="data/protection-status/completed-protection.txt"
-            if [[ -f "$completed_file" ]]; then
-              # 最新の完了エントリから学生IDを抽出
-              latest_entry=$(tail -n 1 "$completed_file" 2>/dev/null || \
-                            echo "")
+            # 環境変数から学生情報を取得
+            processed_student="${{ env.STUDENT_ID }}"
+            processed_repo_type="${{ env.REPO_TYPE }}"
+            
+            if [[ -n "$processed_student" ]] && [[ -n "$processed_repo_type" ]]; then
+              echo "🎯 Processing student: $processed_student (type: $processed_repo_type)"
               
-              # 学生IDを抽出 (例: "k02jk059-sotsuron # Completed: ... Student: k02jk059" から "k02jk059")
-              if [[ "$latest_entry" =~ Student:\ ([k][0-9]{2}(rs|jk|gjk)[0-9]+) ]]; then
-                latest_student="${BASH_REMATCH[1]}"
+              repo_name="${processed_student}-${processed_repo_type}"
+              echo "🔍 Checking repository: smkwlab/$repo_name"
+              
+              # リポジトリの存在確認
+              if gh_output=$(gh repo view "smkwlab/$repo_name" 2>&1); then
+                echo "📦 Found repository: $repo_name"
+
+                # thesis-student-registryを更新
+                cd thesis-student-registry
+                chmod +x update-repository-registry.sh
+                
+                # ステータス決定（週報は自動完了、論文系はブランチ保護後に完了）
+                if [[ "$processed_repo_type" == "wr" ]]; then
+                  status="completed"
+                else
+                  status="completed"  # ここに到達する時点でブランチ保護も完了済み
+                fi
+                
+                script_args=("$repo_name" "$processed_student" "$processed_repo_type" "$status")
+                if ./update-repository-registry.sh "${script_args[@]}" 2>&1; then
+                  echo "✅ Updated registry for: $repo_name"
+                else
+                  echo "⚠️ Failed to update registry for: $repo_name"
+                fi
+                cd ..
               else
-                # フォールバック: リポジトリ名から学生IDを抽出
-                latest_student=$(echo "$latest_entry" | \
-                               grep -oE '^k[0-9]{2}(rs|jk|gjk)[0-9]+' || echo "")
-              fi
-
-              if [[ -n "$latest_student" ]]; then
-                echo "🎯 Processing latest completed student ID:" \
-                     "$latest_student"
-                echo "   From entry: $latest_entry"
-
-                # 複数のリポジトリタイプを処理
-                for repo_type in sotsuron ise-report1 ise-report2 wr; do
-                  repo_name="${latest_student}-${repo_type}"
-                  
-                  echo "🔍 Checking repository: smkwlab/$repo_name"
-                  
-                  # リポジトリの存在確認（詳細エラー出力付き）
-                  if gh_output=$(gh repo view "smkwlab/$repo_name" 2>&1); then
-                    echo "📦 Found repository: $repo_name"
-
-                    # thesis-student-registryを更新
-                    cd thesis-student-registry
-                    chmod +x update-repository-registry.sh
-                    script_args=("$repo_name" "$latest_student" "$repo_type" \
-                                 "completed")
-                    if ./update-repository-registry.sh "${script_args[@]}" \
-                       2>&1; then
-                      echo "✅ Updated registry for: $repo_name"
-                    else
-                      echo "⚠️ Failed to update registry for: $repo_name"
-                      echo "This may be normal if the repository" \
-                           "type is not supported"
-                    fi
-                    cd ..
-                  else
-                    echo "❌ Repository not found or access denied: $repo_name"
-                    echo "   Error: $gh_output"
-                  fi
-                done
-              else
-                echo "⚠️ No recent completed students found"
+                echo "❌ Repository not found or access denied: $repo_name"
+                echo "   Error: $gh_output"
               fi
             else
-              echo "⚠️ completed-protection.txt not found"
-              echo "This is expected on first run or if no" \
-                   "protections have been completed yet"
+              echo "⚠️ Student ID or repo type not available from environment"
+              echo "STUDENT_ID: ${processed_student:-'(empty)'}"
+              echo "REPO_TYPE: ${processed_repo_type:-'(empty)'}"
             fi
           else
             echo "⚠️ thesis-student-registry not found"


### PR DESCRIPTION
## 問題
現在のワークフローでは週報（wr）リポジトリに対してもブランチ保護設定を試行するため、権限不足やリポジトリ構造の違いで失敗し、Issueが蓄積している。

## 解決策
- Issueタイトルからリポジトリタイプ（wr/sotsuron/thesis）を判定
- 週報リポジトリの場合はブランチ保護をスキップ、登録のみ実行
- 環境変数を使用してthesis-student-registry更新処理を簡素化

## 変更内容
1. **リポジトリタイプ判定**：Issueタイトルから`-wr`、`-sotsuron`、`-thesis`を検出
2. **条件分岐処理**：週報は登録のみ、論文系はブランチ保護+登録
3. **環境変数活用**：学生IDとリポジトリタイプを環境変数で渡し、処理を統一
4. **エラーハンドリング改善**：リポジトリタイプ不明時の適切な処理

## 期待される効果
- 週報リポジトリのIssueが正常に自動クローズされる
- 不要なブランチ保護試行が回避される
- ワークフローの成功率向上
- 蓄積されたIssueの解消

## テスト
権限が追加されたORG_ADMIN_TOKENでのテストが必要