### PR TITLE
feat: Add interactive mode enhancements for issue and repository management

### DIFF
--- a/scripts/process-pending-issues.sh
+++ b/scripts/process-pending-issues.sh
@@ -962,7 +962,19 @@ Issue #${CURRENT_ISSUE_NUMBER} を手動でクローズしました。
 #
 execute_issue_delete() {
     echo "⚠️  警告: Issue削除は取り消しできません"
-    echo "Issue #${CURRENT_ISSUE_NUMBER}: ${CURRENT_ISSUE_TITLE}"
+    echo
+    echo "削除対象Issueの詳細情報:"
+    echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+    echo "  Issue番号: #${CURRENT_ISSUE_NUMBER}"
+    echo "  タイトル: ${CURRENT_ISSUE_TITLE}"
+    echo "  作成者: ${CURRENT_ISSUE_AUTHOR}"
+    echo "  作成日時: $(echo "$CURRENT_ISSUE_CREATED" | sed 's/T/ /' | sed 's/Z/ UTC/')"
+    echo "  URL: ${CURRENT_ISSUE_URL}"
+    echo
+    echo "  関連リポジトリ: smkwlab/${CURRENT_REPO_NAME}"
+    echo "  リポジトリタイプ: ${CURRENT_REPO_TYPE}"
+    echo "  学生ID: ${CURRENT_STUDENT_ID}"
+    echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
     echo
     echo -n "本当に削除しますか? [yes/NO]: "
     read -r confirm_delete


### PR DESCRIPTION
## Summary
- Add GitHub account name display in interactive mode
- Add issue close-only and delete options
- Add repository deletion feature for test repositories

## Changes

### 1. GitHub Account Name Display
- Fetch and display issue author information from GitHub API
- Show "発行者: username" in issue summary view
- Provides better context for issue management

### 2. Enhanced Issue Management Options
- **[c] Close Issue**: Close issue without processing repository
- **[d] Delete Issue**: Permanently delete issue (requires admin rights)
- Available in both main menu and detail view

### 3. Repository Deletion Feature
- **[D] Repository Delete**: Safe deletion of test repositories
- Multi-step confirmation process:
  1. Test repository verification
  2. Repository name confirmation
  3. Final confirmation with 'DELETE-PERMANENTLY'
- Automatic issue closure with deletion details

## Safety Features
- Test repository verification prevents accidental production deletions
- Multiple confirmation steps ensure intentional actions
- Clear warnings about permanent data loss
- Admin permission requirements enforced

## Test Plan
- [ ] Test GitHub account name display in interactive mode
- [ ] Test issue close-only functionality
- [ ] Test issue deletion with proper permissions
- [ ] Test repository deletion confirmation flow
- [ ] Verify cancellation works at each step
- [ ] Test error handling for insufficient permissions