### PR TITLE
fix: Correct function call syntax in interactive mode handlers

### DIFF
--- a/scripts/process-pending-issues.sh
+++ b/scripts/process-pending-issues.sh
@@ -712,19 +712,23 @@ process_issue_interactive() {
         case "$choice" in
             p|P)
                 echo
-                return execute_issue_processing
+                execute_issue_processing
+                return $?
                 ;;
             c|C)
                 echo
-                return execute_issue_close_only
+                execute_issue_close_only
+                return $?
                 ;;
             d)
                 echo
-                return execute_issue_delete
+                execute_issue_delete
+                return $?
                 ;;
             D)
                 echo
-                return execute_repository_delete
+                execute_repository_delete
+                return $?
                 ;;
             s|S)
                 echo


### PR DESCRIPTION
## Summary
Fix `return: function_name: numeric argument required` errors in interactive mode

## Problem
The previous fix attempt still had the wrong syntax. Functions were not being executed due to incorrect return statement usage.

## Solution
Changed from:
```bash
return execute_issue_delete
```

To:
```bash
execute_issue_delete
return $?
```

## Affected Options
- [p] Process execution
- [c] Issue close-only  
- [d] Issue delete
- [D] Repository delete

## Test Result
The error messages `return: execute_issue_delete: numeric argument required` should no longer appear, and the functions will execute properly when options are selected.