### PR TITLE
Fix function call syntax in interactive mode menu handlers

### DIFF
--- a/scripts/process-pending-issues.sh
+++ b/scripts/process-pending-issues.sh
@@ -712,19 +712,23 @@ process_issue_interactive() {
         case "$choice" in
             p|P)
                 echo
-                return execute_issue_processing
+                execute_issue_processing
+                return $?
                 ;;
             c|C)
                 echo
-                return execute_issue_close_only
+                execute_issue_close_only
+                return $?
                 ;;
             d)
                 echo
-                return execute_issue_delete
+                execute_issue_delete
+                return $?
                 ;;
             D)
                 echo
-                return execute_repository_delete
+                execute_repository_delete
+                return $?
                 ;;
             s|S)
                 echo


### PR DESCRIPTION
## Summary
インタラクティブモードのメニューハンドラーで関数呼び出し構文を修正

## 修正内容

### 問題
`process-pending-issues.sh`のインタラクティブモードで、以下の構文が正しく動作していない：
```bash
return execute_issue_processing
```

### 修正
関数の戻り値を正しく処理するため、以下のように修正：
```bash
execute_issue_processing
return $?
```

### 影響範囲
- `process_issue_interactive()` 関数内の4つのメニューオプション
  - p|P: `execute_issue_processing`
  - c|C: `execute_issue_close_only` 
  - d: `execute_issue_delete`
  - D: `execute_repository_delete`

## 動作確認
- [x] スクリプトの構文チェック（shellcheck）
- [x] 各メニューオプションの戻り値が正しく処理されることを確認

## 効果
- インタラクティブモードでの処理がより正確に実行される
- 関数の戻り値に基づく適切なエラーハンドリングが可能