### PR TITLE
Simplify repository deletion confirmation in interactive mode

### DIFF
--- a/scripts/process-pending-issues.sh
+++ b/scripts/process-pending-issues.sh
@@ -1043,36 +1043,22 @@ execute_repository_delete() {
     echo -n "これはテスト用リポジトリですか? [yes/NO]: "
     read -r is_test_repo
     
-    if [ "$is_test_repo" != "yes" ]; then
-        echo "❌ テスト用リポジトリ以外の削除はキャンセルされました"
+    if [ "$is_test_repo" = "yes" ]; then
+        # 二重確認：リポジトリ名の入力
         echo
-        echo "続行するには Enter を押してください..."
-        read -r
-        return 0
-    fi
-    
-    # 二重確認：リポジトリ名の入力
-    echo
-    echo "⚠️  最終確認: リポジトリを完全に削除します"
-    echo "確認のため、リポジトリ名を正確に入力してください"
-    echo -n "リポジトリ名 '${CURRENT_REPO_NAME}' を入力: "
-    read -r confirm_repo_name
-    
-    if [ "$confirm_repo_name" != "$CURRENT_REPO_NAME" ]; then
-        echo "❌ リポジトリ名が一致しません。削除をキャンセルしました"
-        echo
-        echo "続行するには Enter を押してください..."
-        read -r
-        return 0
-    fi
-    
-    # 最終確認
-    echo
-    echo "🔴 最終確認: 本当に削除を実行しますか?"
-    echo -n "削除を実行する場合は 'DELETE-PERMANENTLY' と入力: "
-    read -r final_confirm
-    
-    if [ "$final_confirm" = "DELETE-PERMANENTLY" ]; then
+        echo "⚠️  最終確認: リポジトリを完全に削除します"
+        echo "確認のため、リポジトリ名を正確に入力してください"
+        echo -n "リポジトリ名 '${CURRENT_REPO_NAME}' を入力: "
+        read -r confirm_repo_name
+        
+        if [ "$confirm_repo_name" != "$CURRENT_REPO_NAME" ]; then
+            echo "❌ リポジトリ名が一致しません。削除をキャンセルしました"
+            echo
+            echo "続行するには Enter を押してください..."
+            read -r
+            return 0
+        fi
+        
         echo
         echo "リポジトリ削除中..."
         echo
@@ -1109,7 +1095,11 @@ execute_repository_delete() {
             return 1
         fi
     else
-        echo "❌ 削除をキャンセルしました"
+        echo "❌ テスト用リポジトリ以外の削除はキャンセルされました"
+        echo
+        echo "続行するには Enter を押してください..."
+        read -r
+        return 0
     fi
     
     echo

--- a/scripts/process-pending-issues.sh
+++ b/scripts/process-pending-issues.sh
@@ -1026,7 +1026,7 @@ execute_repository_delete() {
     
     # リポジトリ情報の詳細確認
     echo "リポジトリの詳細情報を確認中..."
-    if gh repo view "smkwlab/$CURRENT_REPO_NAME" --json name,description,createdAt,isPrivate --jq '{name: .name, description: .description, created: .createdAt, private: .isPrivate}' 2>/dev/null; then
+    if gh --no-pager repo view "smkwlab/$CURRENT_REPO_NAME" --json name,description,createdAt,isPrivate --jq '{name: .name, description: .description, created: .createdAt, private: .isPrivate}' 2>/dev/null; then
         echo
     else
         echo "❌ リポジトリ情報の取得に失敗しました"

--- a/scripts/process-pending-issues.sh
+++ b/scripts/process-pending-issues.sh
@@ -1051,12 +1051,18 @@ execute_repository_delete() {
         echo -n "リポジトリ名 '${CURRENT_REPO_NAME}' を入力: "
         read -r confirm_repo_name
         
-        if [ -z "$confirm_repo_name" ] || [ "$confirm_repo_name" != "$CURRENT_REPO_NAME" ]; then
-            if [ -z "$confirm_repo_name" ]; then
-                echo "❌ リポジトリ名が入力されていません。削除をキャンセルしました"
-            else
-                echo "❌ リポジトリ名が一致しません。削除をキャンセルしました"
-            fi
+        # 空文字チェック
+        if [ -z "$confirm_repo_name" ]; then
+            echo "❌ リポジトリ名が入力されていません。削除をキャンセルしました"
+            echo
+            echo "続行するには Enter を押してください..."
+            read -r
+            return 0
+        fi
+        
+        # リポジトリ名一致チェック
+        if [ "$confirm_repo_name" != "$CURRENT_REPO_NAME" ]; then
+            echo "❌ リポジトリ名が一致しません。削除をキャンセルしました"
             echo
             echo "続行するには Enter を押してください..."
             read -r

--- a/scripts/process-pending-issues.sh
+++ b/scripts/process-pending-issues.sh
@@ -712,19 +712,23 @@ process_issue_interactive() {
         case "$choice" in
             p|P)
                 echo
-                return execute_issue_processing
+                execute_issue_processing
+                return $?
                 ;;
             c|C)
                 echo
-                return execute_issue_close_only
+                execute_issue_close_only
+                return $?
                 ;;
             d)
                 echo
-                return execute_issue_delete
+                execute_issue_delete
+                return $?
                 ;;
             D)
                 echo
-                return execute_repository_delete
+                execute_repository_delete
+                return $?
                 ;;
             s|S)
                 echo

--- a/scripts/process-pending-issues.sh
+++ b/scripts/process-pending-issues.sh
@@ -1051,8 +1051,12 @@ execute_repository_delete() {
         echo -n "リポジトリ名 '${CURRENT_REPO_NAME}' を入力: "
         read -r confirm_repo_name
         
-        if [ "$confirm_repo_name" != "$CURRENT_REPO_NAME" ]; then
-            echo "❌ リポジトリ名が一致しません。削除をキャンセルしました"
+        if [ -z "$confirm_repo_name" ] || [ "$confirm_repo_name" != "$CURRENT_REPO_NAME" ]; then
+            if [ -z "$confirm_repo_name" ]; then
+                echo "❌ リポジトリ名が入力されていません。削除をキャンセルしました"
+            else
+                echo "❌ リポジトリ名が一致しません。削除をキャンセルしました"
+            fi
             echo
             echo "続行するには Enter を押してください..."
             read -r


### PR DESCRIPTION
## Summary
インタラクティブモードでのリポジトリ削除確認を簡略化

## 修正内容

### 削除した確認ステップ
- `DELETE-PERMANENTLY`の入力要求を削除
- 複雑な最終確認プロセスを簡略化

### 保持した安全対策
✅ **「これはテスト用リポジトリですか？」確認**
✅ **リポジトリ名の再入力による確認**

## 新しい削除フロー

```
1. 「これはテスト用リポジトリですか？」 [yes/NO]
   ↓ (yes)
2. 「リポジトリ名 'repo-name' を入力:」
   ↓ (名前が一致)
3. 削除実行
```

## 効果

### ✅ 改善点
- **操作時間短縮**: 不必要な確認ステップを削除
- **使いやすさ向上**: より直感的な操作フロー
- **安全性維持**: 重要な確認は保持

### 🔒 安全対策
- テスト用リポジトリのみ削除可能
- リポジトリ名の正確な入力が必要
- 誤操作防止機能は維持

## 動作確認
- [x] テスト用リポジトリ確認が正常に動作
- [x] リポジトリ名確認が正常に動作
- [x] 削除キャンセル機能が正常に動作

この変更により、必要な安全対策を維持しながら、より効率的な削除操作が可能になります。