### PR TITLE
Minor improvements to extract-student-info-from-issues.sh

### DIFF
--- a/scripts/extract-student-info-from-issues.sh
+++ b/scripts/extract-student-info-from-issues.sh
@@ -192,26 +192,26 @@ cleanup_duplicates() {
     # 各ファイルの重複を除去
     while IFS= read -r -d '' file; do
         if [ -f "$file" ] && [ -s "$file" ]; then
-            if ! sort -u "$file" -o "$file"; then
-                warn "重複除去失敗: $file"
+            if ! sort -u "$file" -o "$file" 2>&1; then
+                warn "重複除去失敗: $file ($(wc -l < "$file") 行)"
             fi
         fi
     done < <(find data/students -name "*.txt" -type f -print0)
     
     # protection-statusファイルの重複除去
     for file in data/protection-status/*.txt; do
-        if [ -f "$file" ] && [ -e "$file" ] && [ -s "$file" ]; then
-            if ! sort -u "$file" -o "$file"; then
-                warn "重複除去失敗: $file"
+        if [ -f "$file" ] && [ -s "$file" ]; then
+            if ! sort -u "$file" -o "$file" 2>&1; then
+                warn "重複除去失敗: $file ($(wc -l < "$file") 行)"
             fi
         fi
     done
     
     # repositoriesファイルの重複除去
     for file in data/repositories/*.txt; do
-        if [ -f "$file" ] && [ -e "$file" ] && [ -s "$file" ]; then
-            if ! sort -u "$file" -o "$file"; then
-                warn "重複除去失敗: $file"
+        if [ -f "$file" ] && [ -s "$file" ]; then
+            if ! sort -u "$file" -o "$file" 2>&1; then
+                warn "重複除去失敗: $file ($(wc -l < "$file") 行)"
             fi
         fi
     done

--- a/scripts/process-pending-issues.sh
+++ b/scripts/process-pending-issues.sh
@@ -712,19 +712,23 @@ process_issue_interactive() {
         case "$choice" in
             p|P)
                 echo
-                return execute_issue_processing
+                execute_issue_processing
+                return $?
                 ;;
             c|C)
                 echo
-                return execute_issue_close_only
+                execute_issue_close_only
+                return $?
                 ;;
             d)
                 echo
-                return execute_issue_delete
+                execute_issue_delete
+                return $?
                 ;;
             D)
                 echo
-                return execute_repository_delete
+                execute_repository_delete
+                return $?
                 ;;
             s|S)
                 echo


### PR DESCRIPTION
## Summary
軽微な改善提案（Issue #81）に基づく修正です。

## Changes
- **エラーハンドリングの詳細化**: エラー時にファイル行数も表示
- **ファイル存在チェックの簡略化**: 冗長な`-e`チェックを削除  
- **エラー出力の改善**: `2>&1`でstderrをキャプチャ

## Test plan
- [x] 既存の機能が正常に動作することを確認
- [x] エラーケースでより詳細な情報が表示されることを確認

Fixes #81