### PR TITLE
Add individual user support for setup.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,22 +5,28 @@ GitHub を使った効率的な論文指導をサポートします。
 
 ## 対象ユーザー
 
-- **学生**: 論文執筆・提出
+### 組織内ユーザー（smkwlab）
+- **学生**: 論文執筆・提出（PR添削ワークフロー付き）
 - **教員**: 論文添削・指導
 - **管理者**: レビューワークフロー管理
 - **TA・先輩**: 副指導・レビュー支援
 
-## 🎓 学生の方へ
+### 個人ユーザー（組織外）
+- **個人研究者・学習者**: LaTeX環境での文書作成
+- **他大学の学生**: 個人的なLaTeX論文執筆環境
 
-**論文執筆用リポジトリの作成方法**
+## 🎓 LaTeX環境のセットアップ
 
-### 📋 セットアップスクリプトを使用
+### 組織内学生向け（smkwlab所属）
+
+**PR添削ワークフロー付き論文執筆環境の作成**
 
 **前提条件:**
 - Windows: WSL + Docker Desktop
 - macOS: Docker Desktop
 - GitHub CLI（推奨、認証を大幅に簡素化）
 
+**セットアップコマンド:**
 ```bash
 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/smkwlab/thesis-management-tools/main/create-repo/setup.sh)"
 ```
@@ -43,6 +49,38 @@ gh auth switch --user your-username
 # または個人アカウントに作成
 TARGET_ORG=your-username /bin/bash -c "$(curl -fsSL ...)"
 ```
+
+### 個人ユーザー向け（組織外）
+
+**高品質なLaTeX文書作成環境を個人でも利用可能**
+
+smkwlab組織に所属していない方でも、同じセットアップスクリプトで個人用のLaTeX環境を構築できます。組織外ユーザーは自動的に個人モードで動作します。
+
+**セットアップコマンド:**
+```bash
+# 自動判定（推奨）- 組織外ユーザーは自動的に個人モードになります
+/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/smkwlab/thesis-management-tools/main/create-repo/setup.sh)"
+
+# 明示的に個人モード指定（組織メンバーが個人利用したい場合）
+INDIVIDUAL_MODE=true /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/smkwlab/thesis-management-tools/main/create-repo/setup.sh)"
+```
+
+**個人モードの特徴:**
+| 機能 | 個人モード | 組織モード |
+|------|-----------|-----------|
+| LaTeX環境 (DevContainer) | ✅ 提供 | ✅ 提供 |
+| textlint日本語校正 | ✅ 提供 | ✅ 提供 |
+| VS Code統合 | ✅ 提供 | ✅ 提供 |
+| リポジトリ作成先 | 個人アカウント | smkwlab組織 |
+| ブランチ保護 | ❌ なし | ✅ 自動設定 |
+| PR添削ワークフロー | ❌ なし | ✅ 教員レビュー |
+| 進捗管理 | ❌ なし | ✅ 組織レベル |
+
+**実行手順:**
+1. `gh auth login` でGitHubにログイン
+2. 上記コマンドを実行
+3. リポジトリ名のベースを入力（例: your-username, my-thesis など）
+4. 個人用LaTeX環境が自動設定されます
 
 ### 📚 手動テンプレート使用
 1. [sotsuron-template](https://github.com/smkwlab/sotsuron-template) にアクセス

--- a/create-repo/main.sh
+++ b/create-repo/main.sh
@@ -160,9 +160,31 @@ if [ "$INDIVIDUAL_MODE" = true ]; then
         exit 1
     fi
     
-    # 個人ユーザーは常にsotsuron（卒業論文相当）
-    THESIS_TYPE="sotsuron"
-    echo -e "${BLUE}✓ 個人LaTeX文書として設定します (sotsuron形式)${NC}"
+    # 論文タイプの決定（環境変数優先、なければインタラクティブ選択）
+    if [ -n "$THESIS_TYPE" ] && [ "$THESIS_TYPE" = "thesis" ]; then
+        echo -e "${BLUE}✓ 修士論文形式として設定します${NC}"
+    elif [ -n "$THESIS_TYPE" ] && [ "$THESIS_TYPE" = "sotsuron" ]; then
+        echo -e "${BLUE}✓ 卒業論文形式として設定します${NC}"
+    else
+        # インタラクティブ選択
+        echo ""
+        echo "論文タイプを選択してください："
+        echo "  1. 卒業論文 (sotsuron) - 学部論文向け"
+        echo "  2. 修士論文 (thesis) - 大学院論文向け"
+        echo ""
+        read -p "選択 [1]: " thesis_choice
+        
+        case "${thesis_choice:-1}" in
+            2)
+                THESIS_TYPE="thesis"
+                echo -e "${BLUE}✓ 修士論文形式として設定します${NC}"
+                ;;
+            *)
+                THESIS_TYPE="sotsuron"
+                echo -e "${BLUE}✓ 卒業論文形式として設定します${NC}"
+                ;;
+        esac
+    fi
 else
     # 組織ユーザーモード: 従来通りの学籍番号正規化と判定
     NORMALIZED_STUDENT_ID=$(normalize_student_id "$STUDENT_ID")

--- a/create-repo/main.sh
+++ b/create-repo/main.sh
@@ -162,26 +162,26 @@ if [ "$INDIVIDUAL_MODE" = true ]; then
     
     # 論文タイプの決定（環境変数優先、なければインタラクティブ選択）
     if [ -n "$THESIS_TYPE" ] && [ "$THESIS_TYPE" = "thesis" ]; then
-        echo -e "${BLUE}✓ 修士論文形式として設定します${NC}"
+        echo -e "${BLUE}✓ 修士論文リポジトリとして設定します${NC}"
     elif [ -n "$THESIS_TYPE" ] && [ "$THESIS_TYPE" = "sotsuron" ]; then
-        echo -e "${BLUE}✓ 卒業論文形式として設定します${NC}"
+        echo -e "${BLUE}✓ 卒業論文リポジトリとして設定します${NC}"
     else
         # インタラクティブ選択
         echo ""
         echo "論文タイプを選択してください："
-        echo "  1. 卒業論文 (sotsuron) - 学部論文向け"
-        echo "  2. 修士論文 (thesis) - 大学院論文向け"
+        echo "  1. 卒業論文"
+        echo "  2. 修士論文"
         echo ""
         read -p "選択 [1]: " thesis_choice
         
         case "${thesis_choice:-1}" in
             2)
                 THESIS_TYPE="thesis"
-                echo -e "${BLUE}✓ 修士論文形式として設定します${NC}"
+                echo -e "${BLUE}✓ 修士論文リポジトリとして設定します${NC}"
                 ;;
             *)
                 THESIS_TYPE="sotsuron"
-                echo -e "${BLUE}✓ 卒業論文形式として設定します${NC}"
+                echo -e "${BLUE}✓ 卒業論文リポジトリとして設定します${NC}"
                 ;;
         esac
     fi
@@ -205,13 +205,13 @@ else
     # 論文タイプの判定
     if [[ "$STUDENT_ID" =~ ^k[0-9]{2}rs[0-9]{3}$ ]]; then
         THESIS_TYPE="sotsuron"
-        echo -e "${GREEN}✓ 卒業論文として設定します${NC}"
+        echo -e "${GREEN}✓ 卒業論文リポジトリとして設定します${NC}"
     elif [[ "$STUDENT_ID" =~ ^k[0-9]{2}jk[0-9]{3}$ ]]; then
         THESIS_TYPE="sotsuron"
-        echo -e "${GREEN}✓ 卒業論文として設定します${NC}"
+        echo -e "${GREEN}✓ 卒業論文リポジトリとして設定します${NC}"
     elif [[ "$STUDENT_ID" =~ ^k[0-9]{2}gjk[0-9]{2}$ ]]; then
         THESIS_TYPE="thesis"
-        echo -e "${GREEN}✓ 修士論文として設定します${NC}"
+        echo -e "${GREEN}✓ 修士論文リポジトリとして設定します${NC}"
     else
         echo -e "${RED}エラー: 学籍番号の形式が正しくありません${NC}"
         echo "期待される形式:"

--- a/create-repo/setup.sh
+++ b/create-repo/setup.sh
@@ -94,8 +94,47 @@ fi
 
 echo "✅ GitHub認証済み (ユーザー: $CURRENT_USER)"
 
+# ユーザータイプ判定関数
+detect_user_type() {
+    local current_user="$1"
+    
+    if [ "${DEBUG:-0}" = "1" ]; then
+        echo "🔍 ユーザータイプを判定中: $current_user"
+    fi
+    
+    # INDIVIDUAL_MODE環境変数による明示的指定
+    if [ "${INDIVIDUAL_MODE:-false}" = "true" ]; then
+        echo "individual_user"
+        return 0
+    fi
+    
+    # smkwlab組織メンバーシップを確認
+    if gh api "orgs/smkwlab/members/$current_user" >/dev/null 2>&1; then
+        echo "organization_member"
+    else
+        echo "individual_user"
+    fi
+}
+
+# ユーザータイプの判定
+USER_TYPE=$(detect_user_type "$CURRENT_USER")
+
+if [ "${DEBUG:-0}" = "1" ]; then
+    echo "🔍 判定結果: $USER_TYPE"
+fi
+
 # TARGET_ORG（対象組織）の設定
-TARGET_ORG="${TARGET_ORG:-smkwlab}"
+if [ "$USER_TYPE" = "individual_user" ]; then
+    # 個人ユーザーの場合、デフォルトを個人アカウントに設定
+    TARGET_ORG="${TARGET_ORG:-$CURRENT_USER}"
+    echo "👤 個人ユーザーモードで実行中"
+    echo "   作成先: $TARGET_ORG (個人アカウント)"
+else
+    # 組織ユーザーの場合、従来通り
+    TARGET_ORG="${TARGET_ORG:-smkwlab}"
+    echo "🏢 組織ユーザーモードで実行中"
+    echo "   作成先: $TARGET_ORG (組織)"
+fi
 
 # TARGET_ORG が指定されている場合、アカウントの整合性をチェック
 if [ -n "$TARGET_ORG" ] && [ "$TARGET_ORG" != "smkwlab" ]; then
@@ -183,14 +222,17 @@ echo "🚀 セットアップ実行中..."
 cd "$ORIGINAL_DIR"
 
 # Docker実行（TTY対応、GitHub認証トークンをセキュアファイル経由で渡す）
+# 動作モード情報を環境変数として渡す
+DOCKER_ENV_VARS="-e USER_TYPE=$USER_TYPE -e TARGET_ORG=$TARGET_ORG"
+
 if [ -n "$STUDENT_ID" ]; then
-    if ! docker run --rm -it -v "$TOKEN_FILE:/tmp/gh_token:ro" thesis-setup-alpine "$STUDENT_ID"; then
+    if ! docker run --rm -it $DOCKER_ENV_VARS -v "$TOKEN_FILE:/tmp/gh_token:ro" thesis-setup-alpine "$STUDENT_ID"; then
         echo "❌ セットアップスクリプトの実行に失敗しました"
         echo "学籍番号: $STUDENT_ID"
         exit 1
     fi
 else
-    if ! docker run --rm -it -v "$TOKEN_FILE:/tmp/gh_token:ro" thesis-setup-alpine; then
+    if ! docker run --rm -it $DOCKER_ENV_VARS -v "$TOKEN_FILE:/tmp/gh_token:ro" thesis-setup-alpine; then
         echo "❌ セットアップスクリプトの実行に失敗しました"
         exit 1
     fi

--- a/scripts/process-pending-issues.sh
+++ b/scripts/process-pending-issues.sh
@@ -712,19 +712,23 @@ process_issue_interactive() {
         case "$choice" in
             p|P)
                 echo
-                return execute_issue_processing
+                execute_issue_processing
+                return $?
                 ;;
             c|C)
                 echo
-                return execute_issue_close_only
+                execute_issue_close_only
+                return $?
                 ;;
             d)
                 echo
-                return execute_issue_delete
+                execute_issue_delete
+                return $?
                 ;;
             D)
                 echo
-                return execute_repository_delete
+                execute_repository_delete
+                return $?
                 ;;
             s|S)
                 echo


### PR DESCRIPTION
Issue #166で提案された個人ユーザー対応を実装しました。組織外ユーザーが個人アカウント下でLaTeX環境を利用できるようになります。

## 主な変更点
- 組織メンバーシップ自動判定によるユーザータイプ検出
- 個人モードでのリポジトリ作成 (username/username-sotsuron)
- 管理機能（ブランチ保護・Registry・Issue作成）のスキップ
- README.mdに個人ユーザー向けセクションを追加

## 使用方法
自動判定により組織外ユーザーは個人モードで動作します。

Resolves #166