### PR TITLE
Fix Git user configuration in main-latex.sh

### DIFF
--- a/create-repo/main-latex.sh
+++ b/create-repo/main-latex.sh
@@ -399,6 +399,10 @@ fi
 # 変更をコミットしてプッシュ
 echo "📤 変更をコミット中..."
 
+# Gitユーザー設定（Docker環境用）
+git config user.email "setup-latex@smkwlab.github.io"
+git config user.name "LaTeX Setup Tool"
+
 git add .
 git commit -m "Initial customization for ${DOCUMENT_NAME}
 


### PR DESCRIPTION
## 問題

setup-latex.shの実行時に以下のエラーが発生：

```
Author identity unknown

*** Please tell me who you are.

Run

  git config --global user.email "you@example.com"
  git config --global user.name "Your Name"

to set your account's default identity.
fatal: unable to auto-detect email address (got 'root@aa46b37c25f6.(none)')
```

## 解決策

main-latex.shにGitユーザー設定を追加：

```bash
# Gitユーザー設定（Docker環境用）
git config user.email "setup-latex@smkwlab.github.io"
git config user.name "LaTeX Setup Tool"
```

## 他スクリプトとの一貫性

既存のsetupスクリプト（main.sh、main-wr.sh、setup-ise.sh）と同じパターンに統一。

## 検証

- Docker環境でのGitコミット時の身元不明エラーを解決
- セットアップツール用の適切な身元設定
- 既存パターンとの整合性確保

これにより、setup-latex.shが正常に動作するようになります。