### PR TITLE
Fix Git authentication setup in main-latex.sh

### DIFF
--- a/create-repo/main-latex.sh
+++ b/create-repo/main-latex.sh
@@ -399,6 +399,16 @@ fi
 # 変更をコミットしてプッシュ
 echo "📤 変更をコミット中..."
 
+# GitHub CLIの認証情報をgitに設定
+# これによりgit pushコマンドが認証プロンプトなしで実行可能になる
+echo "Git認証を設定中..."
+if ! gh auth setup-git; then
+    echo -e "${RED}✗ Git認証設定に失敗しました${NC}"
+    echo -e "${RED}GitHub CLIの認証が正しく設定されているか確認してください${NC}"
+    exit 1
+fi
+echo -e "${GREEN}✓ Git認証設定完了${NC}"
+
 # Gitユーザー設定（Docker環境用）
 git config user.email "setup-latex@smkwlab.github.io"
 git config user.name "LaTeX Setup Tool"


### PR DESCRIPTION
## 問題

setup-latex.shのGitプッシュ時に認証プロンプトが表示され、失敗する：

```
Username for 'https://github.com':
Password for 'https://github.com':
remote: No anonymous write access.
fatal: Authentication failed
```

## 原因

GitHub CLIの認証情報がGitに正しく設定されていない。

## 解決策

`gh auth setup-git` コマンドを追加：

```bash
if \! gh auth setup-git; then
    echo -e "${RED}✗ Git認証設定に失敗しました${NC}"
    exit 1
fi
```

## 他スクリプトとの一貫性

main.sh、main-wr.sh、setup-ise.shと同じパターンに統一。

## 効果

setup-latex.shが最後まで正常に動作するようになります。