### PR TITLE
Fix latex and ise repository type processing in process-pending-issues.sh

### DIFF
--- a/scripts/process-pending-issues.sh
+++ b/scripts/process-pending-issues.sh
@@ -157,8 +157,8 @@ parse_options() {
                 ;;
             --type)
                 FILTER_TYPE="$2"
-                if [[ ! "$FILTER_TYPE" =~ ^(wr|sotsuron|thesis)$ ]]; then
-                    log_error "無効なタイプ: $FILTER_TYPE (有効: wr, sotsuron, thesis)"
+                if [[ ! "$FILTER_TYPE" =~ ^(wr|sotsuron|thesis|ise|latex)$ ]]; then
+                    log_error "無効なタイプ: $FILTER_TYPE (有効: wr, sotsuron, thesis, ise, latex)"
                     exit 1
                 fi
                 shift 2
@@ -445,7 +445,7 @@ extract_issue_info() {
         CURRENT_REPO_TYPE="wr"
     elif [[ "$CURRENT_REPO_NAME" == *"-ise-report"* ]]; then
         CURRENT_REPO_TYPE="ise"
-    elif [[ "$CURRENT_REPO_NAME" == *"-latex" ]]; then
+    elif [[ "$CURRENT_REPO_NAME" == *"-latex" ]] || [[ "$CURRENT_REPO_NAME" =~ -[a-zA-Z0-9_-]+$ && ! "$CURRENT_REPO_NAME" =~ -(wr|sotsuron|thesis|ise-report) ]]; then
         CURRENT_REPO_TYPE="latex"
     elif [[ "$CURRENT_REPO_NAME" == *"-sotsuron" ]]; then
         CURRENT_REPO_TYPE="sotsuron"


### PR DESCRIPTION
## Summary
- Add support for `latex` and `ise` repository types in `process-pending-issues.sh`
- Fix Issue #199 processing failure for `k02jk059-report59` repository
- Improve repository type detection for various naming patterns

## Changes Made
- Add `latex` and `ise` to valid types in `--type` option validation
- Enhance latex repository pattern matching to handle patterns like `-report59`, `-research-note`, etc.
- Update help documentation to include new repository types

## Test Results
- ✅ `--type latex` option now works correctly
- ✅ Repository name patterns like `k02jk059-report59` are properly detected as latex type
- ✅ Issue #199 was successfully processed and closed

## Background
Issue #199 failed to process because `k02jk059-report59` was not recognized as a valid repository type. The script only supported `wr`, `sotsuron`, and `thesis` types, but students are now creating `latex` and `ise` repositories through the updated setup scripts.

This fix ensures all repository types created by the ecosystem are properly handled by the processing script.