### PR TITLE
Fix regex patterns for repository name and type extraction (Issue #204)

### DIFF
--- a/scripts/process-pending-issues.sh
+++ b/scripts/process-pending-issues.sh
@@ -402,15 +402,15 @@ extract_issue_info() {
     # リポジトリ名抽出（複数パターン対応）
     CURRENT_REPO_NAME=""
     
-    # パターン1: smkwlab/k##xxx-yyy 形式
-    if [[ "$CURRENT_ISSUE_TITLE" =~ smkwlab/([k][0-9]{2}[a-z0-9]+-[a-z]+) ]]; then
+    # パターン1: smkwlab/k##xxx-yyy 形式（数字を含む名前に対応）
+    if [[ "$CURRENT_ISSUE_TITLE" =~ smkwlab/([k][0-9]{2}[a-z0-9]+-[a-zA-Z0-9_-]+) ]]; then
         CURRENT_REPO_NAME="${BASH_REMATCH[1]}"
     # パターン2: Issue本文からリポジトリ名を抽出
-    elif [[ "$CURRENT_ISSUE_BODY" =~ smkwlab/([k][0-9]{2}[a-z0-9]+-[a-z]+) ]]; then
+    elif [[ "$CURRENT_ISSUE_BODY" =~ smkwlab/([k][0-9]{2}[a-z0-9]+-[a-zA-Z0-9_-]+) ]]; then
         CURRENT_REPO_NAME="${BASH_REMATCH[1]}"
         log_debug "Issue #${CURRENT_ISSUE_NUMBER}: 本文からリポジトリ名を抽出: $CURRENT_REPO_NAME"
     # パターン3: より柔軟なパターン（バックティック囲み等）
-    elif [[ "$CURRENT_ISSUE_TITLE$CURRENT_ISSUE_BODY" =~ \`([k][0-9]{2}[a-z0-9]+-[a-z]+)\` ]]; then
+    elif [[ "$CURRENT_ISSUE_TITLE$CURRENT_ISSUE_BODY" =~ \`([k][0-9]{2}[a-z0-9]+-[a-zA-Z0-9_-]+)\` ]]; then
         CURRENT_REPO_NAME="${BASH_REMATCH[1]}"
         log_debug "Issue #${CURRENT_ISSUE_NUMBER}: バックティック囲みからリポジトリ名を抽出: $CURRENT_REPO_NAME"
     else
@@ -441,7 +441,7 @@ extract_issue_info() {
     CURRENT_REPO_TYPE=""
     
     # パターン1: Issue本文から直接抽出（最も信頼性が高い）
-    if [[ "$CURRENT_ISSUE_BODY" =~ リポジトリタイプ.*:.*([a-z]+) ]]; then
+    if [[ "$CURRENT_ISSUE_BODY" =~ リポジトリタイプ[[:space:]]*:[[:space:]]*([a-z]+) ]]; then
         CURRENT_REPO_TYPE="${BASH_REMATCH[1]}"
         log_debug "Issue #${CURRENT_ISSUE_NUMBER}: Issue本文から直接タイプを抽出: $CURRENT_REPO_TYPE"
     # パターン2: Issue本文のキーワードから判定


### PR DESCRIPTION
## Problem

Issue #204 で `k02jk059-memo02` リポジトリの処理が失敗していました。デバッグの結果、2つの正規表現の問題が判明しました：

1. **リポジトリ名の抽出**: `k02jk059-memo02` → `k02jk059-memo` に切り詰められる
2. **タイプ抽出**: `リポジトリタイプ: latex` → `o` しか抽出されない

## Root Cause

### リポジトリ名抽出の問題
```bash
# 問題のあった正規表現
[k][0-9]{2}[a-z0-9]+-[a-z]+
```
- `[a-z]+` の部分が `memo` までしかマッチしない
- `02` 部分を取り逃していた

### タイプ抽出の問題  
```bash
# 問題のあった正規表現
リポジトリタイプ.*:.*([a-z]+)
```
- `.*` がスペースを正しく処理できていない
- `latex` の最後の文字しか抽出されていない

## Solution

### 1. リポジトリ名抽出の修正
```bash
# Before
[k][0-9]{2}[a-z0-9]+-[a-z]+

# After  
[k][0-9]{2}[a-z0-9]+-[a-zA-Z0-9_-]+
```

以下のパターンすべてに対応：
- `k02jk059-memo02` ✅
- `k21rs001-report59` ✅ 
- `k19rs999-research-note` ✅

### 2. タイプ抽出の修正
```bash
# Before
リポジトリタイプ.*:.*([a-z]+)

# After
リポジトリタイプ[[:space:]]*:[[:space:]]*([a-z]+)
```

正確なスペース処理により確実に `latex` を抽出

## Test Case

**Issue #204のケース**:
- **Before**: `k02jk059-memo` (wrong) + type `o` (wrong) → リポジトリが見つからない
- **After**: `k02jk059-memo02` (correct) + type `latex` (correct) → 正常処理

## Impact

- Issue #204 の処理失敗が解決
- 数字を含む複雑なリポジトリ名に対応
- タイプ抽出の信頼性向上
- 今後の類似問題を予防

この修正により、あらゆる命名パターンのリポジトリが正確に処理されるようになります。