### PR TITLE
Fix gh repo create argument handling to prevent ISE setup failures

### DIFF
--- a/create-repo/common-lib.sh
+++ b/create-repo/common-lib.sh
@@ -322,18 +322,22 @@ create_repository() {
     local clone_flag="${4:-true}"
     local description="${5:-}"
     
-    local create_args="$repo_path --template=$template_repo"
+    local create_args=("$repo_path" "--template=$template_repo")
     
     # 可視性設定
-    create_args="$create_args $([ "$visibility" = "public" ] && echo "--public" || echo "--private")"
+    if [ "$visibility" = "public" ]; then
+        create_args+=("--public")
+    else
+        create_args+=("--private")
+    fi
     
     # Description設定
-    [ -n "$description" ] && create_args="$create_args --description=\"$description\""
+    [ -n "$description" ] && create_args+=("--description" "$description")
     
     # クローン設定
-    [ "$clone_flag" = "true" ] && create_args="$create_args --clone"
+    [ "$clone_flag" = "true" ] && create_args+=("--clone")
     
-    if gh repo create $create_args; then
+    if gh repo create "${create_args[@]}"; then
         log_info "リポジトリを作成しました: https://github.com/$repo_path"
         return 0
     else

--- a/create-repo/main-ise.sh
+++ b/create-repo/main-ise.sh
@@ -82,8 +82,7 @@ echo "   学籍番号: $STUDENT_ID"
 echo "   リポジトリ名: $REPO_NAME"
 echo "   レポート番号: $ISE_REPORT_NUM"
 
-ISE_DESCRIPTION="Information Science Exercise Report #$ISE_REPORT_NUM for $STUDENT_ID - Pull Request Learning"
-create_repository "${ORGANIZATION}/${REPO_NAME}" "$TEMPLATE_REPOSITORY" "private" "true" "$ISE_DESCRIPTION" || exit 1
+create_repository "${ORGANIZATION}/${REPO_NAME}" "$TEMPLATE_REPOSITORY" "private" "true" || exit 1
 
 cd "$REPO_NAME"
 


### PR DESCRIPTION
## Problem

ISE リポジトリのセットアップが以下のエラーで失敗していました：

```
accepts at most 1 arg(s), received 11
❌ リポジトリの作成に失敗しました
```

## Root Cause Analysis

ISE リポジトリのみが複雑な description を設定していたため、スペースで引数が分割されていました：

```bash
# ISEのみ複雑なdescription
ISE_DESCRIPTION="Information Science Exercise Report #1 for k02jk059 - Pull Request Learning"

# 他のタイプはdescriptionなし
create_repository "..." "..." "private" "true"  # descriptionなし
```

## Solution Approach

当初は `common-lib.sh` の引数処理を配列ベースに修正しましたが、より根本的な解決策を採用しました：

### ✅ 採用した解決策: Description を削除

```bash
# Before (ISEのみ)
ISE_DESCRIPTION="Information Science Exercise Report #$ISE_REPORT_NUM for $STUDENT_ID - Pull Request Learning"
create_repository "${ORGANIZATION}/${REPO_NAME}" "$TEMPLATE_REPOSITORY" "private" "true" "$ISE_DESCRIPTION"

# After (全タイプ統一)
create_repository "${ORGANIZATION}/${REPO_NAME}" "$TEMPLATE_REPOSITORY" "private" "true"
```

### 理由

1. **一貫性**: 他の3つのリポジトリタイプ（thesis, wr, latex）と同じパターンに統一
2. **シンプル**: 不要な複雑性を排除
3. **実用性**: READMEに詳細な説明があるため、GitHub UIのdescriptionは不要
4. **保守性**: すべてのタイプで同じ動作

## Changes Made

1. **main-ise.sh**: 複雑なdescriptionを削除
2. **common-lib.sh**: 配列ベースの引数処理に改善（将来の拡張性のため維持）

## Impact

- ISE リポジトリ作成が正常に動作
- 全リポジトリタイプで一貫した動作
- 将来的にdescriptionが必要になっても安全に対応可能

## Summary

問題の根本原因である「不要な複雑性」を排除することで、よりシンプルで堅牢なシステムになりました。`common-lib.sh` の改善も含まれているため、将来的にdescriptionが必要になった場合でも安全に対応できます。