### PR TITLE
Change WR repository visibility from public to private

### DIFF
--- a/create-repo/main-wr.sh
+++ b/create-repo/main-wr.sh
@@ -46,7 +46,7 @@ confirm_creation "$REPO_PATH" || exit 0
 # リポジトリ作成（共通関数使用）
 echo ""
 echo "📁 リポジトリを作成中..."
-create_repository "$REPO_PATH" "$TEMPLATE_REPOSITORY" "public" "true" || exit 1
+create_repository "$REPO_PATH" "$TEMPLATE_REPOSITORY" "private" "true" || exit 1
 
 cd "$REPO_NAME"
 


### PR DESCRIPTION
## Summary

週報（WR）リポジトリの可視性を `public` から `private` に変更します。

## 変更理由

1. **プライバシー保護**: 学生の学習記録を外部から保護
2. **組織内共有**: 組織メンバーは引き続きアクセス可能なため、教育的価値は維持
3. **一貫性**: 他の教育系リポジトリ（ISE、Thesis）と同じ設定に統一

## 変更内容

```diff
- create_repository "$REPO_PATH" "$TEMPLATE_REPOSITORY" "public" "true" || exit 1
+ create_repository "$REPO_PATH" "$TEMPLATE_REPOSITORY" "private" "true" || exit 1
```

## 変更後の各リポジトリタイプの可視性

| リポジトリタイプ | 可視性 | 理由 |
|---|---|---|
| **ISE** | private 🔒 | 学習コンテンツの保護 |
| **Thesis** | private 🔒 | 学術成果物の保護 |
| **WR** | private 🔒 | 学習記録の保護（今回変更） |
| **LaTeX** | public 🌐 | 汎用テンプレートのため公開維持 |

## 影響

- **学生**: より安心して週報を作成できる環境
- **教員**: 組織内でのアクセスは変わらず、教育効果は維持
- **外部**: 週報へのアクセス不可（プライバシー保護）

## 結論

組織内での共有と協働は維持しつつ、学生のプライバシーをより適切に保護する設定になります。