### PR TITLE
Implement date-based ISE repository number determination

### DIFF
--- a/create-repo/setup.sh
+++ b/create-repo/setup.sh
@@ -326,6 +326,9 @@ case "$DETECTED_DOC_TYPE" in
         if [ -n "$ASSIGNMENT_TYPE" ]; then
             DOCKER_ENV_VARS="$DOCKER_ENV_VARS -e ASSIGNMENT_TYPE=$ASSIGNMENT_TYPE"
         fi
+        if [ -n "$ISE_REPORT_NUM" ]; then
+            DOCKER_ENV_VARS="$DOCKER_ENV_VARS -e ISE_REPORT_NUM=$ISE_REPORT_NUM"
+        fi
         ;;
 esac
 


### PR DESCRIPTION
## Summary

学期に応じたISEリポジトリ番号の自動決定機能を実装しました。

### Changes
- **前期期間（4-9月）**: ise-report1 を優先的に作成
- **後期期間（10-3月）**: ise-report2 を優先的に作成  
- 優先番号が使用済みの場合、自動的にフォールバック
- `ISE_REPORT_NUM` 環境変数による手動制御をサポート

### Implementation Details
- `determine_ise_report_number` 関数の日時ベースアルゴリズム実装
- setup.sh での環境変数処理追加
- 既存機能との完全な後方互換性を維持

### Usage Examples
```bash
# 自動判定（学期に応じた優先順位）
DOC_TYPE=ise STUDENT_ID=k21rs001 ./create-repo/setup.sh

# 手動指定
ISE_REPORT_NUM=1 DOC_TYPE=ise STUDENT_ID=k21rs001 ./create-repo/setup.sh
ISE_REPORT_NUM=2 DOC_TYPE=ise STUDENT_ID=k21rs001 ./create-repo/setup.sh
```

## Test plan
- [ ] 前期期間での自動判定テスト
- [ ] 後期期間での自動判定テスト  
- [ ] 環境変数による手動制御テスト
- [ ] 既存リポジトリが存在する場合のフォールバックテスト

resolve #213