### PR TITLE
Auto-use GitHub username when student ID input is empty

### DIFF
--- a/create-repo/common-lib.sh
+++ b/create-repo/common-lib.sh
@@ -231,6 +231,12 @@ read_student_id() {
     echo "  例: $examples" >&2
     echo "" >&2
     read -p "学籍番号: " student_id
+    
+    # 無入力の場合、GitHubユーザー名を自動使用（サイレント）
+    if [ -z "$student_id" ]; then
+        student_id=$(gh api user --jq .login 2>/dev/null || echo "")
+    fi
+    
     echo "$student_id"
 }
 

--- a/create-repo/common-lib.sh
+++ b/create-repo/common-lib.sh
@@ -232,9 +232,23 @@ read_student_id() {
     echo "" >&2
     read -p "学籍番号: " student_id
     
-    # 無入力の場合、GitHubユーザー名を自動使用（サイレント）
+    # 無入力の場合、GitHubユーザー名を自動使用
     if [ -z "$student_id" ]; then
-        student_id=$(gh api user --jq .login 2>/dev/null || echo "")
+        # GitHub CLIの存在確認とユーザー名取得
+        if command -v gh >/dev/null 2>&1; then
+            local github_username=$(gh api user --jq .login 2>/dev/null || echo "")
+            if [ -n "$github_username" ]; then
+                # GitHubユーザー名を使用することを通知（開発者向け機能として控えめに）
+                echo -e "${BLUE}→ GitHub ユーザー名を使用: $github_username${NC}" >&2
+                student_id="$github_username"
+            else
+                # GitHub CLIは存在するが認証されていない場合
+                log_debug "GitHub ユーザー名の取得に失敗しました"
+            fi
+        else
+            # GitHub CLIがインストールされていない場合
+            log_debug "GitHub CLIがインストールされていません"
+        fi
     fi
     
     echo "$student_id"


### PR DESCRIPTION
## Summary

学籍番号入力時に無入力（Enterキーのみ）の場合、現在のGitHubユーザー名を自動的に使用する機能を追加しました。

## Implementation

`common-lib.sh` の `read_student_id` 関数を修正：
- 空入力を検出したら `gh api user --jq .login` でユーザー名取得
- ユーザーには何も表示せず、サイレントに処理
- 取得したユーザー名は通常通り検証・正規化される

## Benefits

- 開発者やテスターが素早く自分のアカウントでテスト可能
- 毎回学籍番号を入力する手間を省略
- 既存の動作には影響なし（明示的な入力は従来通り処理）

## Usage

```bash
# 無入力でEnterを押すと現在のGitHubユーザー名を使用
$ ./main-ise.sh
学籍番号を入力してください
  例: k21rs001, k21gjk01

学籍番号: [Enter押下]
# → k18rs509 などが自動設定される
```

## Test plan
- [ ] 無入力時に現在のGitHubユーザー名が使用されることを確認
- [ ] 明示的な入力時は入力値が優先されることを確認
- [ ] 自動取得されたユーザー名も正規化・検証されることを確認