### PR TITLE
Fix main branch push in main-ise.sh

### DIFF
--- a/create-repo/main-ise.sh
+++ b/create-repo/main-ise.sh
@@ -263,6 +263,7 @@ git commit -m "Initial setup for ISE Report #${ISE_REPORT_NUM}
 - Create review-branch and 0th-draft
 - Report: ${REPORT_TITLE} (${REPORT_PERIOD})" >/dev/null 2>&1
 
+git push origin main >/dev/null 2>&1
 echo -e "${GREEN}✓ main ブランチセットアップ完了${NC}"
 
 # STEP 2: 0th-draft ブランチの作成（main から分岐）


### PR DESCRIPTION
## Summary
- main-ise.sh で main ブランチの変更がリモートにプッシュされていない問題を修正

## Problem
- STEP 1 で main ブランチに README.md/REVIEW_BRANCH.md をセットアップ
- しかし `git push origin main` が実行されていない
- 結果として 0th-draft の PR にこれらのファイル変更が含まれてしまう

## Solution
- main ブランチセットアップ後に `git push origin main` を追加
- これにより main ブランチの変更がリモートに反映される
- 0th-draft は main から正しく分岐するため、setup ファイルが PR に含まれない

## Current Push Status
✅ `main`: 新規追加
✅ `review-branch`: 既存
✅ `initial`: 既存  
✅ `0th-draft`: `commit_and_push` 関数で自動実行

## Test Plan
- [ ] 修正版 main-ise.sh でテストリポジトリ作成
- [ ] 0th-draft → main の PR でファイル変更を確認
- [ ] README.md/REVIEW_BRANCH.md が差分に含まれないことを確認

This completes the fix for Issue #241.