### PR TITLE
🚨 URGENT FIX: Remove only index.html in initial branch creation

### DIFF
--- a/create-repo/main-ise.sh
+++ b/create-repo/main-ise.sh
@@ -288,8 +288,8 @@ echo "📝 initial ブランチを作成中..."
 # orphan ブランチとして initial を作成（履歴を継承しない）
 git checkout --orphan initial >/dev/null 2>&1
 
-# 全ファイルをステージングエリアから削除
-git rm -rf . >/dev/null 2>&1
+# index.html のみをステージングエリアから削除
+git rm index.html >/dev/null 2>&1
 
 # 空の index.html のみを作成
 > index.html


### PR DESCRIPTION
## 🚨 **Urgent Fix for PR #246**

### **Critical Issue Found**
PR #246 の修正に重大な欠陥を発見しました。

**Problem with Previous Fix:**
```bash
# PR #246 (Incorrect)
git rm -rf .        # ← 全ファイル削除
> index.html        # ← 空ファイル作成
```

**Result:**
- initial ブランチ: `index.html` のみ
- review-branch: 全テンプレートファイル
- **PR #2 差分: README.md, sample-index.html, style.css など全ファイルが表示**

### **Correct Solution**
```bash
# This PR (Correct)
git rm index.html   # ← index.html のみ削除
> index.html        # ← 空ファイル作成
```

**Expected Result:**
- initial ブランチ: テンプレートファイル + 空の `index.html`
- review-branch: テンプレートファイル + 学生の `index.html`
- **PR #2 差分: index.html のみ表示（期待通り）**

### **Impact of This Fix**

#### **Before This Fix:**
- ❌ PR #2 に全テンプレートファイルが差分として表示
- ❌ review PR が無関係なファイルでクラッター
- ❌ 教員が学生のレポート内容に集中できない

#### **After This Fix:**
- ✅ PR #2 に index.html のみが差分として表示
- ✅ クリーンで焦点の定まったレビュー
- ✅ 教員が学生のレポート内容に集中可能

### **Technical Details**

**File Operations:**
- `git checkout --orphan initial` - 独立ブランチ作成
- `git rm index.html` - index.html のみ削除
- `> index.html` - 空ファイル作成
- 他のテンプレートファイルは保持

**Result Structure:**
```
initial branch:
├── README.md (template)
├── sample-index.html (template)  
├── style.css (template)
├── .github/ (template)
└── index.html (empty) ← 唯一の差分
```

### **Priority: URGENT**
This fixes a critical flaw in the PR #246 implementation that would make review PRs unusable due to template file clutter.

**Required for proper review-branch system functionality.**