### PR TITLE
Fix #250: Make review-branch inherit from initial for PR creation

### DIFF
--- a/create-repo/main-ise.sh
+++ b/create-repo/main-ise.sh
@@ -274,15 +274,7 @@ fi
 echo "📝 0th-draft ブランチを作成中..."
 git checkout -b 0th-draft >/dev/null 2>&1
 
-# STEP 3: review-branch の作成（main から分岐）
-echo "📝 review-branch ブランチを作成中..."
-git checkout main >/dev/null 2>&1
-git checkout -b review-branch >/dev/null 2>&1
-git push origin review-branch >/dev/null 2>&1
-
-echo -e "${GREEN}✓ review-branch 作成完了${NC}"
-
-# STEP 4: initial ブランチを独立したブランチとして作成
+# STEP 3: initial ブランチを独立したブランチとして作成
 echo "📝 initial ブランチを作成中..."
 
 # orphan ブランチとして initial を作成（履歴を継承しない）
@@ -301,6 +293,16 @@ git commit -m "Setup initial branch with empty index.html for full-line PR revie
 git push origin initial >/dev/null 2>&1
 
 echo -e "${GREEN}✓ initial ブランチ作成完了${NC}"
+
+# STEP 4: review-branch の作成（initial から分岐後、main の内容をマージ）
+echo "📝 review-branch ブランチを作成中..."
+git checkout -b review-branch >/dev/null 2>&1
+
+# main ブランチの内容をマージして学生の作業内容を含める
+git merge main --no-edit >/dev/null 2>&1
+git push origin review-branch >/dev/null 2>&1
+
+echo -e "${GREEN}✓ review-branch 作成完了${NC}"
 
 # STEP 5: 0th-draft ブランチに戻る
 git checkout 0th-draft >/dev/null 2>&1

--- a/create-repo/main-ise.sh
+++ b/create-repo/main-ise.sh
@@ -299,8 +299,18 @@ echo "📝 review-branch ブランチを作成中..."
 git checkout -b review-branch >/dev/null 2>&1
 
 # main ブランチの内容をマージして学生の作業内容を含める
-git merge main --no-edit >/dev/null 2>&1
-git push origin review-branch >/dev/null 2>&1
+if ! git merge main --no-edit >/dev/null 2>&1; then
+    echo -e "${RED}❌ review-branch への main ブランチのマージでエラーが発生しました${NC}"
+    echo -e "${YELLOW}   ⚠️ 通常この段階ではコンフリクトは発生しません${NC}"
+    echo -e "${YELLOW}   もし発生した場合は、テンプレートの問題の可能性があります${NC}"
+    echo -e "${YELLOW}   管理者にお問い合わせください${NC}"
+    exit 1
+fi
+
+if ! git push origin review-branch >/dev/null 2>&1; then
+    echo -e "${RED}❌ review-branch のプッシュに失敗しました${NC}"
+    exit 1
+fi
 
 echo -e "${GREEN}✓ review-branch 作成完了${NC}"
 


### PR DESCRIPTION
## 概要

orphan ブランチ導入により review-branch から initial への PR 作成が失敗する問題を修正します。

## 問題

PR #246-248 で initial ブランチを orphan ブランチに変更したことにより：
- review-branch（main から分岐）と initial（orphan）の間に共通履歴がない
- GitHub が共通履歴のないブランチ間での PR 作成を拒否
- エラー: `The review-branch branch has no history in common with initial`

## 解決方法

review-branch を initial から分岐するよう変更：
1. orphan の initial ブランチ作成（空の index.html）
2. review-branch を initial から分岐
3. main ブランチの内容を review-branch にマージ

これにより：
- review-branch と initial に共通履歴が確保される
- GitHub で initial ← review-branch の PR 作成が可能
- 全行コメント可能性も維持される

## 変更内容

- `main-ise.sh`: review-branch 作成順序を変更
  - STEP 3: initial ブランチ作成（orphan）
  - STEP 4: review-branch を initial から分岐し、main をマージ

## 関連 PR

- ise-report-template #42: update-review-branch.yml の一貫性確保

## テスト方法

```bash
# setup.sh 経由でテスト
STUDENT_ID=k99rs999 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/smkwlab/thesis-management-tools/issue-250-fix-orphan-branch-pr-creation/create-repo/setup-ise.sh)"
```

resolve #250