### PR TITLE
Fix orphan branch merge issue in main-ise.sh

### DIFF
--- a/create-repo/main-ise.sh
+++ b/create-repo/main-ise.sh
@@ -299,7 +299,7 @@ echo "📝 review-branch ブランチを作成中..."
 git checkout -b review-branch >/dev/null 2>&1
 
 # main ブランチの内容をマージして学生の作業内容を含める
-if ! git merge main --no-edit >/dev/null 2>&1; then
+if ! git merge main --no-edit --allow-unrelated-histories >/dev/null 2>&1; then
     echo -e "${RED}❌ review-branch への main ブランチのマージでエラーが発生しました${NC}"
     echo -e "${YELLOW}   ⚠️ 通常この段階ではコンフリクトは発生しません${NC}"
     echo -e "${YELLOW}   もし発生した場合は、テンプレートの問題の可能性があります${NC}"


### PR DESCRIPTION
## 問題

setup.sh の実行で以下のエラーが発生：

```
❌ review-branch への main ブランチのマージでエラーが発生しました
```

## 根本原因

1. initial ブランチが orphan ブランチとして作成される
2. review-branch が initial から分岐する  
3. main ブランチを review-branch にマージしようとすると、共通祖先がないためエラー：
   `fatal: refusing to merge unrelated histories`

## 解決方法

`--allow-unrelated-histories` フラグを追加：

```bash
git merge main --no-edit --allow-unrelated-histories
```

これにより orphan ブランチと通常ブランチ間のマージが可能になります。

## 関連 PR

- ise-report-template でも同様の修正を実施中