### PR TITLE
Apply orphan branch fixes from ISE template to thesis template

### DIFF
--- a/create-repo/main-thesis.sh
+++ b/create-repo/main-thesis.sh
@@ -93,12 +93,14 @@ echo "📝 initial ブランチを作成中..."
 git checkout --orphan initial >/dev/null 2>&1
 
 # LaTeX ファイルを除去し、プレースホルダーファイルのみを作成
-git rm --cached --ignore-unmatch *.tex *.cls *.sty >/dev/null 2>&1 || true
+if ! git rm --cached --ignore-unmatch *.tex *.cls *.sty >/dev/null 2>&1; then
+    echo -e "${YELLOW}⚠️ LaTeX ファイルの削除に失敗しました。ファイルが存在しない可能性があります。${NC}" >&2
+fi
 
 # 空のプレースホルダーファイルを作成
 > .tex_placeholder
 git add .tex_placeholder >/dev/null 2>&1
-git commit -m "Setup initial branch with empty placeholder for full-line PR reviews
+git commit -m "Setup initial branch with empty placeholder
 
 - Empty placeholder for student content creation
 - Orphan branch with no history for proper diff comparison" >/dev/null 2>&1
@@ -114,13 +116,14 @@ git checkout -b review-branch >/dev/null 2>&1
 if ! git merge main --no-edit --allow-unrelated-histories >/dev/null 2>&1; then
     echo -e "${RED}❌ review-branch への main ブランチのマージでエラーが発生しました${NC}"
     echo -e "${YELLOW}   ⚠️ 通常この段階ではコンフリクトは発生しません${NC}"
-    echo -e "${YELLOW}   もし発生した場合は、テンプレートの問題の可能性があります${NC}"
+    echo -e "${YELLOW}   考えられる原因: テンプレートの問題、または学生による誤った変更${NC}"
     echo -e "${YELLOW}   管理者にお問い合わせください${NC}"
     exit 1
 fi
 
 if ! git push origin review-branch >/dev/null 2>&1; then
     echo -e "${RED}❌ review-branch のプッシュに失敗しました${NC}"
+    echo -e "${YELLOW}   考えられる原因: 権限不足、ネットワークの問題、またはリモートリポジトリの設定${NC}"
     exit 1
 fi
 

--- a/create-repo/main-thesis.sh
+++ b/create-repo/main-thesis.sh
@@ -86,10 +86,45 @@ echo "ブランチを設定中..."
 git add . >/dev/null 2>&1
 git diff-index --quiet HEAD -- || git commit -m "Initialize repository with template cleanup" >/dev/null 2>&1 || true
 
-if ! git rev-parse --verify review-branch >/dev/null 2>&1; then
-    git checkout -b review-branch >/dev/null 2>&1
-    git push -u origin review-branch >/dev/null 2>&1
+# STEP 3: initial ブランチを独立したブランチとして作成
+echo "📝 initial ブランチを作成中..."
+
+# orphan ブランチとして initial を作成（履歴を継承しない）
+git checkout --orphan initial >/dev/null 2>&1
+
+# LaTeX ファイルを除去し、プレースホルダーファイルのみを作成
+git rm --cached --ignore-unmatch *.tex *.cls *.sty >/dev/null 2>&1 || true
+
+# 空のプレースホルダーファイルを作成
+> .tex_placeholder
+git add .tex_placeholder >/dev/null 2>&1
+git commit -m "Setup initial branch with empty placeholder for full-line PR reviews
+
+- Empty placeholder for student content creation
+- Orphan branch with no history for proper diff comparison" >/dev/null 2>&1
+git push origin initial >/dev/null 2>&1
+
+echo -e "${GREEN}✓ initial ブランチ作成完了${NC}"
+
+# STEP 4: review-branch の作成（initial から分岐後、main の内容をマージ）
+echo "📝 review-branch ブランチを作成中..."
+git checkout -b review-branch >/dev/null 2>&1
+
+# main ブランチの内容をマージして学生の作業内容を含める
+if ! git merge main --no-edit --allow-unrelated-histories >/dev/null 2>&1; then
+    echo -e "${RED}❌ review-branch への main ブランチのマージでエラーが発生しました${NC}"
+    echo -e "${YELLOW}   ⚠️ 通常この段階ではコンフリクトは発生しません${NC}"
+    echo -e "${YELLOW}   もし発生した場合は、テンプレートの問題の可能性があります${NC}"
+    echo -e "${YELLOW}   管理者にお問い合わせください${NC}"
+    exit 1
 fi
+
+if ! git push origin review-branch >/dev/null 2>&1; then
+    echo -e "${RED}❌ review-branch のプッシュに失敗しました${NC}"
+    exit 1
+fi
+
+echo -e "${GREEN}✓ review-branch 作成完了${NC}"
 git checkout main >/dev/null 2>&1
 
 # Issue作成（組織モードのみ）


### PR DESCRIPTION
## Summary
main-thesis.sh に main-ise.sh で修正済みの orphan branch 対応を適用しました。

## Changes
### 1. Initial branch creation (orphan)
- `git checkout --orphan initial` で独立したブランチを作成
- LaTeX ファイルを除去し、`.tex_placeholder` ファイルを作成
- orphan branch として履歴を継承しない構造

### 2. Review-branch creation from initial
- review-branch を initial から分岐するように変更
- main ブランチの内容を `--allow-unrelated-histories` でマージ
- エラーハンドリングを実装

## Technical Details
main-ise.sh で実装済みの以下の修正を適用：
- Issue #250: review-branch を initial から分岐
- Issue #252: --allow-unrelated-histories フラグ追加
- Issue #235: initial branch の orphan 作成
- Issue #246: review-branch 作成の一貫性修正

## Before/After
**Before:**
```bash
git checkout -b review-branch
git push -u origin review-branch
```

**After:**
```bash
# Create orphan initial branch
git checkout --orphan initial
git rm --cached --ignore-unmatch *.tex *.cls *.sty
echo '' > .tex_placeholder
git add .tex_placeholder
git commit -m "Setup initial branch..."
git push origin initial

# Create review-branch from initial
git checkout -b review-branch
git merge main --no-edit --allow-unrelated-histories
git push origin review-branch
```

## Benefits
- PR 作成時の "No common history" エラー防止
- full-line PR comments の有効化
- main-ise.sh との一貫性確保
- setup.sh 実行時の merge エラー解消

## Related Issues
- #250: main-ise.sh での初期修正
- #252: --allow-unrelated-histories 追加
- sotsuron-template #71: ワークフロー修正（関連）

Resolves #261