### PR TITLE
Fix local variable declaration error in main-ise.sh

### DIFF
--- a/create-repo/main-ise.sh
+++ b/create-repo/main-ise.sh
@@ -301,12 +301,12 @@ echo "🔒 review-branch のブランチ保護を設定中..."
 if [ "$INDIVIDUAL_MODE" = false ]; then
     # 組織リポジトリの場合はreview-branchも保護
     # 保護設定をJSONファイルから読み込み
-    local protection_config_file="${SCRIPT_DIR}/protection-config.json"
+    protection_config_file="${SCRIPT_DIR}/protection-config.json"
     if [ ! -f "$protection_config_file" ]; then
         echo -e "${YELLOW}⚠️ 保護設定ファイルが見つかりません: $protection_config_file${NC}"
         echo -e "${YELLOW}   review-branch のブランチ保護設定をスキップします${NC}"
     else
-        local protection_config=$(cat "$protection_config_file")
+        protection_config=$(cat "$protection_config_file")
         
         if echo "$protection_config" | gh api "repos/${ORGANIZATION}/${REPO_NAME}/branches/review-branch/protection" \
             --method PUT \


### PR DESCRIPTION
## Summary
main-ise.sh のブランチ保護設定部分で発生していた `local: can only be used in a function` エラーを修正

## Problem
- ISEレポートリポジトリ作成時に main-ise.sh:304行目でエラー発生
- `local` 宣言を関数外で使用していたため、bashスクリプトエラー
- セットアップが最終段階で失敗していた

## Solution
- 304行目: `local protection_config_file=` → `protection_config_file=`
- 309行目: `local protection_config=` → `protection_config=`
- 関数外では `local` 宣言不要のため削除

## Testing
- ✅ bash構文チェック成功
- ✅ 既存の関数内local宣言はそのまま維持
- ✅ スクリプトの機能に変更なし

## Files Changed
- `create-repo/main-ise.sh`: local宣言2箇所を修正

## Impact
今後のISEレポートリポジトリ作成でブランチ保護設定エラーが解消される

Resolves #270