### PR TITLE
Fix local variable declaration in main-thesis.sh

### DIFF
--- a/create-repo/main-thesis.sh
+++ b/create-repo/main-thesis.sh
@@ -111,12 +111,12 @@ echo "🔒 review-branch のブランチ保護を設定中..."
 if [ "$INDIVIDUAL_MODE" = false ]; then
     # 組織リポジトリの場合はreview-branchも保護
     # 保護設定をJSONファイルから読み込み
-    local protection_config_file="${SCRIPT_DIR}/protection-config.json"
+    protection_config_file="${SCRIPT_DIR}/protection-config.json"
     if [ ! -f "$protection_config_file" ]; then
         echo -e "${YELLOW}⚠️ 保護設定ファイルが見つかりません: $protection_config_file${NC}"
         echo -e "${YELLOW}   review-branch のブランチ保護設定をスキップします${NC}"
     else
-        local protection_config=$(cat "$protection_config_file")
+        protection_config=$(cat "$protection_config_file")
         
         if echo "$protection_config" | gh api "repos/${ORGANIZATION}/${REPO_NAME}/branches/review-branch/protection" \
             --method PUT \


### PR DESCRIPTION
## Summary

Fix 'local: can only be used in a function' error in main-thesis.sh during thesis repository setup.

## Problem

During k19rs999-sotsuron repository creation, setup.sh failed with:


## Root Cause

Lines 114 and 119 in main-thesis.sh were using 'local' keyword outside of function scope:
- Line 114:   
- Line 119: 

This is the same issue that was previously fixed in main-ise.sh.

## Solution

Remove 'local' keywords from both variable declarations since they are used in main script scope, not function scope.

## Changes

- Line 114:  → 
- Line 119:  → 

## Testing

This fix aligns with the correction made in main-ise.sh and resolves the syntax error preventing thesis repository setup completion.