### PR TITLE
Fix main-thesis.sh template cleanup issues (#289)

### DIFF
--- a/create-repo/main-thesis.sh
+++ b/create-repo/main-thesis.sh
@@ -77,6 +77,18 @@ setup_git_user "thesis-setup@smkwlab.github.io" "Thesis Setup Tool"
 # テンプレート整理
 echo "テンプレートファイルを整理中..."
 rm -f CLAUDE.md 2>/dev/null || true
+rm -rf docs/ 2>/dev/null || true
+
+# 論文タイプに応じて不要なファイルを削除
+if [ "$THESIS_TYPE" = "shuuron" ]; then
+    # 修士論文: sotsuron.tex, gaiyou.tex を削除
+    rm -f sotsuron.tex gaiyou.tex 2>/dev/null || true
+    echo "修士論文用: sotsuron.tex, gaiyou.tex を削除しました"
+elif [ "$THESIS_TYPE" = "sotsuron" ]; then
+    # 卒業論文: thesis.tex, abstract.tex を削除
+    rm -f thesis.tex abstract.tex 2>/dev/null || true
+    echo "卒業論文用: thesis.tex, abstract.tex を削除しました"
+fi
 
 # LaTeX環境のセットアップ（共通関数使用）
 setup_latex_environment

--- a/create-repo/main-thesis.sh
+++ b/create-repo/main-thesis.sh
@@ -111,12 +111,12 @@ echo "🔒 review-branch のブランチ保護を設定中..."
 if [ "$INDIVIDUAL_MODE" = false ]; then
     # 組織リポジトリの場合はreview-branchも保護
     # 保護設定をJSONファイルから読み込み
-    local protection_config_file="${SCRIPT_DIR}/protection-config.json"
+    protection_config_file="${SCRIPT_DIR}/protection-config.json"
     if [ ! -f "$protection_config_file" ]; then
         echo -e "${YELLOW}⚠️ 保護設定ファイルが見つかりません: $protection_config_file${NC}"
         echo -e "${YELLOW}   review-branch のブランチ保護設定をスキップします${NC}"
     else
-        local protection_config=$(cat "$protection_config_file")
+        protection_config=$(cat "$protection_config_file")
         
         if echo "$protection_config" | gh api "repos/${ORGANIZATION}/${REPO_NAME}/branches/review-branch/protection" \
             --method PUT \


### PR DESCRIPTION
## Issue #289の解決

k19rs999-sotsuronリポジトリで発生していた問題の根本原因である **main-thesis.sh** の不具合を修正しました。

## 修正内容

### 1. テンプレートファイル削除の追加
- **CLAUDE.md**: テンプレートファイルの削除処理を追加
- **docs/ディレクトリ**: テンプレートディレクトリの削除処理を追加

### 2. 論文タイプ別不要ファイル削除の実装
- **卒業論文 (sotsuron)**: `thesis.tex`, `abstract.tex` の削除処理を追加
- **修士論文 (shuuron)**: `sotsuron.tex`, `gaiyou.tex` の削除処理を追加

## 修正により解決される問題

✅ **0th-draftブランチ作成成功**: 不要ファイルが削除されてからsetup_review_workflow実行
✅ **適切なファイル構成**: 論文タイプに応じた正しいファイルのみ残存
✅ **テンプレート成果物のクリーンアップ**: CLAUDE.md, docs/の適切な削除

## テスト計画

- [ ] 新しい卒業論文リポジトリでのテスト
- [ ] 新しい修士論文リポジトリでのテスト
- [ ] setup_review_workflowの正常動作確認

## 関連Issue

Closes #289