### PR TITLE
Fix missing template file cleanup in setup scripts

### DIFF
--- a/create-repo/main-ise.sh
+++ b/create-repo/main-ise.sh
@@ -178,6 +178,8 @@ setup_git_user "setup-ise@smkwlab.github.io" "ISE Setup Tool"
 
 # STEP 1: main ブランチでファイルをセットアップ
 echo "テンプレートファイルを整理中..."
+rm -f CLAUDE.md 2>/dev/null || true
+rm -rf docs/ 2>/dev/null || true
 
 # main ブランチでの初期セットアップコミット
 git add .

--- a/create-repo/main-thesis.sh
+++ b/create-repo/main-thesis.sh
@@ -81,6 +81,7 @@ setup_latex_environment
 echo "テンプレートファイルを整理中..."
 rm -f CLAUDE.md 2>/dev/null || true
 rm -rf docs/ 2>/dev/null || true
+rm -f README.md-aldc .????*-aldc 2>/dev/null || true
 
 # 論文タイプに応じて不要なファイルを削除
 if [ "$THESIS_TYPE" = "shuuron" ]; then

--- a/create-repo/main-thesis.sh
+++ b/create-repo/main-thesis.sh
@@ -111,12 +111,12 @@ echo "🔒 review-branch のブランチ保護を設定中..."
 if [ "$INDIVIDUAL_MODE" = false ]; then
     # 組織リポジトリの場合はreview-branchも保護
     # 保護設定をJSONファイルから読み込み
-    local protection_config_file="${SCRIPT_DIR}/protection-config.json"
+    protection_config_file="${SCRIPT_DIR}/protection-config.json"
     if [ ! -f "$protection_config_file" ]; then
         echo -e "${YELLOW}⚠️ 保護設定ファイルが見つかりません: $protection_config_file${NC}"
         echo -e "${YELLOW}   review-branch のブランチ保護設定をスキップします${NC}"
     else
-        local protection_config=$(cat "$protection_config_file")
+        protection_config=$(cat "$protection_config_file")
         
         if echo "$protection_config" | gh api "repos/${ORGANIZATION}/${REPO_NAME}/branches/review-branch/protection" \
             --method PUT \


### PR DESCRIPTION
## 概要

セットアップスクリプトでのテンプレートファイル整理に漏れがあったため、不足していた削除処理を追加します。

## 修正内容

### main-ise.sh
- **CLAUDE.md削除**: テンプレートファイルの削除処理を追加
- **docs/削除**: テンプレートディレクトリの削除処理を追加

### main-thesis.sh  
- **README.md-aldc削除**: aldcが生成するREADMEバックアップファイルの削除
- **.????*-aldc削除**: aldcが生成する隠しファイルの削除

## 修正の必要性

これらのファイルが残存すると：
- 学生リポジトリに不要なテンプレートファイルが含まれる
- aldcによる一時ファイルが蓄積される
- リポジトリの整合性が保たれない

## 影響範囲

- **main-ise.sh**: ISEレポートリポジトリ作成時のファイルクリーンアップ改善
- **main-thesis.sh**: 論文リポジトリ作成時のaldcファイルクリーンアップ改善

## テスト

- [ ] 新しいISEレポートリポジトリでのファイル削除確認
- [ ] 新しい論文リポジトリでのaldcファイル削除確認

## 関連

前回のPR #290で実装した統一構造に対する追加改善です。