### PR TITLE
Fix setup-branch-protection.sh arguments in process-pending-issues.sh

### DIFF
--- a/scripts/process-pending-issues.sh
+++ b/scripts/process-pending-issues.sh
@@ -1499,7 +1499,7 @@ process_thesis_issue() {
     log_info "論文リポジトリ処理: $CURRENT_REPO_NAME"
     
     # 1. ブランチ保護設定
-    if ! "$SCRIPT_DIR/setup-branch-protection.sh" "$CURRENT_STUDENT_ID" "$CURRENT_REPO_NAME"; then
+    if ! "$SCRIPT_DIR/setup-branch-protection.sh" "$CURRENT_REPO_NAME"; then
         log_error "ブランチ保護設定に失敗: $CURRENT_REPO_NAME"
         return 1
     fi
@@ -1552,7 +1552,7 @@ process_ise_issue() {
     fi
     
     # 2. ブランチ保護設定
-    if ! "$SCRIPT_DIR/setup-branch-protection.sh" "$CURRENT_STUDENT_ID" "$CURRENT_REPO_NAME"; then
+    if ! "$SCRIPT_DIR/setup-branch-protection.sh" "$CURRENT_REPO_NAME"; then
         log_error "ブランチ保護設定に失敗: $CURRENT_REPO_NAME"
         return 1
     fi


### PR DESCRIPTION
## Summary
- Fix `setup-branch-protection.sh` argument format in `process-pending-issues.sh`
- Remove student ID argument from function calls
- Align with Issue #313 changes that modified `setup-branch-protection.sh` to accept only repository name

## Problem
Issue #316 failed to auto-process because `process-pending-issues.sh` was calling `setup-branch-protection.sh` with old argument format:

```bash
# OLD (causing failure)
setup-branch-protection.sh "$CURRENT_STUDENT_ID" "$CURRENT_REPO_NAME"  # k19rs999 k19rs999-ise-report1

# NEW (correct)
setup-branch-protection.sh "$CURRENT_REPO_NAME"  # k19rs999-ise-report1
```

This caused error: `Repository not found: smkwlab/k19rs999` instead of checking `smkwlab/k19rs999-ise-report1`.

## Changes Made
- **L1502**: Fixed thesis repository processing argument
- **L1555**: Fixed ISE repository processing argument  
- Both now pass only repository name as required

## Impact
- Fixes Issue #316 and similar ISE/thesis repository auto-processing failures
- Ensures compatibility with Issue #313 changes
- Resolves "Repository not found" errors in GitHub Actions

## Test Plan
- [x] Verify `setup-branch-protection.sh --help` shows correct usage
- [x] Confirmed argument format matches Issue #313 implementation
- [ ] Test with actual ISE repository after merge

Fixes: Issue #316 auto-processing failure
Related: Issue #313 `setup-branch-protection.sh` argument changes