### PR TITLE
Enable flexible LaTeX repository creation in individual mode

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,6 +20,9 @@ DOC_TYPE=ise /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/smkwla
 
 # Advanced configuration with environment variables
 DOC_TYPE=latex STUDENT_ID=k21rs001 DOCUMENT_NAME=research-note AUTHOR_NAME="Taro Yamada" /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/smkwlab/thesis-management-tools/main/create-repo/setup.sh)"
+
+# Individual mode for personal LaTeX documents (no student ID required)
+INDIVIDUAL_MODE=true DOC_TYPE=latex DOCUMENT_NAME=my-paper /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/smkwlab/thesis-management-tools/main/create-repo/setup.sh)"
 ```
 
 ### Branch Protection Setup (Faculty)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,6 +23,9 @@ DOC_TYPE=latex STUDENT_ID=k21rs001 DOCUMENT_NAME=research-note AUTHOR_NAME="Taro
 
 # Individual mode for personal LaTeX documents (no student ID required)
 INDIVIDUAL_MODE=true DOC_TYPE=latex DOCUMENT_NAME=my-paper /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/smkwlab/thesis-management-tools/main/create-repo/setup.sh)"
+
+# Disable Registry Manager integration (for testing or isolated use)
+ENABLE_REGISTRY_MANAGER=false DOC_TYPE=latex STUDENT_ID=k21rs001 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/smkwlab/thesis-management-tools/main/create-repo/setup.sh)"
 ```
 
 ### Branch Protection Setup (Faculty)
@@ -82,6 +85,11 @@ Universal Setup Script uses `DOC_TYPE` environment variable to specify document 
 DOCUMENT_NAME=research-note    # Custom document name
 AUTHOR_NAME="Taro Yamada"      # Author name
 ENABLE_PROTECTION=true         # Enable branch protection
+ENABLE_REGISTRY_MANAGER=false  # Disable Registry Manager integration
+
+# Individual mode behavior (DOC_TYPE=latex only)
+INDIVIDUAL_MODE=true           # Skip student ID input, create in personal account
+# Note: When INDIVIDUAL_MODE=true, any STUDENT_ID argument is ignored
 
 # ISE report configuration
 ASSIGNMENT_TYPE=exercise       # Assignment type

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,9 +23,6 @@ DOC_TYPE=latex STUDENT_ID=k21rs001 DOCUMENT_NAME=research-note AUTHOR_NAME="Taro
 
 # Individual mode for personal LaTeX documents (no student ID required)
 INDIVIDUAL_MODE=true DOC_TYPE=latex DOCUMENT_NAME=my-paper /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/smkwlab/thesis-management-tools/main/create-repo/setup.sh)"
-
-# Disable Registry Manager integration (for testing or isolated use)
-ENABLE_REGISTRY_MANAGER=false DOC_TYPE=latex STUDENT_ID=k21rs001 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/smkwlab/thesis-management-tools/main/create-repo/setup.sh)"
 ```
 
 ### Branch Protection Setup (Faculty)
@@ -85,11 +82,11 @@ Universal Setup Script uses `DOC_TYPE` environment variable to specify document 
 DOCUMENT_NAME=research-note    # Custom document name
 AUTHOR_NAME="Taro Yamada"      # Author name
 ENABLE_PROTECTION=true         # Enable branch protection
-ENABLE_REGISTRY_MANAGER=false  # Disable Registry Manager integration
 
 # Individual mode behavior (DOC_TYPE=latex only)
 INDIVIDUAL_MODE=true           # Skip student ID input, create in personal account
 # Note: When INDIVIDUAL_MODE=true, any STUDENT_ID argument is ignored
+# Note: Individual mode automatically disables Registry Manager integration
 
 # ISE report configuration
 ASSIGNMENT_TYPE=exercise       # Assignment type

--- a/create-repo/main-latex.sh
+++ b/create-repo/main-latex.sh
@@ -103,11 +103,14 @@ commit_and_push "Initial customization for ${DOCUMENT_NAME}
 - Setup LaTeX environment
 " || exit 1
 
-# Registry Manager連携（組織ユーザーのみ、かつ学籍番号がある場合）
-if [ "$INDIVIDUAL_MODE" = false ] && [ -n "$STUDENT_ID" ] && gh repo view "${ORGANIZATION}/thesis-student-registry" &>/dev/null; then
+# Registry Manager連携（明示的に有効化された組織ユーザーのみ、かつ学籍番号がある場合）
+ENABLE_REGISTRY_MANAGER="${ENABLE_REGISTRY_MANAGER:-true}"
+if [ "$INDIVIDUAL_MODE" = false ] && [ -n "$STUDENT_ID" ] && [ "$ENABLE_REGISTRY_MANAGER" = true ] && gh repo view "${ORGANIZATION}/thesis-student-registry" &>/dev/null; then
     if ! create_repository_issue "$REPO_NAME" "$STUDENT_ID" "latex" "$ORGANIZATION"; then
         echo -e "${YELLOW}⚠️ Registry Manager登録でエラーが発生しました。手動で登録が必要な場合があります。${NC}"
     fi
+elif [ "$INDIVIDUAL_MODE" = false ] && [ -n "$STUDENT_ID" ] && [ "$ENABLE_REGISTRY_MANAGER" = false ]; then
+    echo -e "${BLUE}📝 Registry Manager連携は無効化されています（ENABLE_REGISTRY_MANAGER=false）${NC}"
 fi
 
 # 完了メッセージ

--- a/create-repo/main-latex.sh
+++ b/create-repo/main-latex.sh
@@ -103,14 +103,11 @@ commit_and_push "Initial customization for ${DOCUMENT_NAME}
 - Setup LaTeX environment
 " || exit 1
 
-# Registry Manager連携（明示的に有効化された組織ユーザーのみ、かつ学籍番号がある場合）
-ENABLE_REGISTRY_MANAGER="${ENABLE_REGISTRY_MANAGER:-true}"
-if [ "$INDIVIDUAL_MODE" = false ] && [ -n "$STUDENT_ID" ] && [ "$ENABLE_REGISTRY_MANAGER" = true ] && gh repo view "${ORGANIZATION}/thesis-student-registry" &>/dev/null; then
+# Registry Manager連携（組織ユーザーのみ、かつ学籍番号がある場合）
+if [ "$INDIVIDUAL_MODE" = false ] && [ -n "$STUDENT_ID" ] && gh repo view "${ORGANIZATION}/thesis-student-registry" &>/dev/null; then
     if ! create_repository_issue "$REPO_NAME" "$STUDENT_ID" "latex" "$ORGANIZATION"; then
         echo -e "${YELLOW}⚠️ Registry Manager登録でエラーが発生しました。手動で登録が必要な場合があります。${NC}"
     fi
-elif [ "$INDIVIDUAL_MODE" = false ] && [ -n "$STUDENT_ID" ] && [ "$ENABLE_REGISTRY_MANAGER" = false ]; then
-    echo -e "${BLUE}📝 Registry Manager連携は無効化されています（ENABLE_REGISTRY_MANAGER=false）${NC}"
 fi
 
 # 完了メッセージ

--- a/create-repo/main-latex.sh
+++ b/create-repo/main-latex.sh
@@ -20,12 +20,18 @@ ORGANIZATION=$(determine_organization)
 TEMPLATE_REPOSITORY="${ORGANIZATION}/latex-template"
 echo -e "${GREEN}✓ テンプレートリポジトリ: $TEMPLATE_REPOSITORY${NC}"
 
-# 学籍番号の入力
-STUDENT_ID=$(read_student_id "$1")
-
-# 学籍番号の正規化と検証
-STUDENT_ID=$(normalize_student_id "$STUDENT_ID") || exit 1
-echo -e "${GREEN}✓ 学籍番号: $STUDENT_ID${NC}"
+# INDIVIDUAL_MODEの場合は学籍番号をスキップ
+if [ "$INDIVIDUAL_MODE" = true ]; then
+    echo -e "${BLUE}📝 個人モード: 学籍番号の入力をスキップします${NC}"
+    STUDENT_ID=""
+else
+    # 学籍番号の入力
+    STUDENT_ID=$(read_student_id "$1")
+    
+    # 学籍番号の正規化と検証
+    STUDENT_ID=$(normalize_student_id "$STUDENT_ID") || exit 1
+    echo -e "${GREEN}✓ 学籍番号: $STUDENT_ID${NC}"
+fi
 
 # ドキュメント名の入力
 read_document_name() {
@@ -49,7 +55,13 @@ read_document_name() {
 }
 
 read_document_name
-REPO_NAME="${STUDENT_ID}-${DOCUMENT_NAME}"
+
+# リポジトリ名の決定
+if [ "$INDIVIDUAL_MODE" = true ]; then
+    REPO_NAME="${DOCUMENT_NAME}"
+else
+    REPO_NAME="${STUDENT_ID}-${DOCUMENT_NAME}"
+fi
 
 # 組織アクセス確認
 check_organization_access "$ORGANIZATION"
@@ -91,8 +103,8 @@ commit_and_push "Initial customization for ${DOCUMENT_NAME}
 - Setup LaTeX environment
 " || exit 1
 
-# Registry Manager連携（組織ユーザーのみ）
-if [ "$INDIVIDUAL_MODE" = false ] && gh repo view "${ORGANIZATION}/thesis-student-registry" &>/dev/null; then
+# Registry Manager連携（組織ユーザーのみ、かつ学籍番号がある場合）
+if [ "$INDIVIDUAL_MODE" = false ] && [ -n "$STUDENT_ID" ] && gh repo view "${ORGANIZATION}/thesis-student-registry" &>/dev/null; then
     if ! create_repository_issue "$REPO_NAME" "$STUDENT_ID" "latex" "$ORGANIZATION"; then
         echo -e "${YELLOW}⚠️ Registry Manager登録でエラーが発生しました。手動で登録が必要な場合があります。${NC}"
     fi

--- a/create-repo/main-latex.sh
+++ b/create-repo/main-latex.sh
@@ -104,6 +104,7 @@ commit_and_push "Initial customization for ${DOCUMENT_NAME}
 " || exit 1
 
 # Registry Manager連携（組織ユーザーのみ、かつ学籍番号がある場合）
+# 条件: 個人モードが無効 AND 学籍番号が存在 AND Registryリポジトリがアクセス可能
 if [ "$INDIVIDUAL_MODE" = false ] && [ -n "$STUDENT_ID" ] && gh repo view "${ORGANIZATION}/thesis-student-registry" &>/dev/null; then
     if ! create_repository_issue "$REPO_NAME" "$STUDENT_ID" "latex" "$ORGANIZATION"; then
         echo -e "${YELLOW}⚠️ Registry Manager登録でエラーが発生しました。手動で登録が必要な場合があります。${NC}"

--- a/create-repo/setup.sh
+++ b/create-repo/setup.sh
@@ -320,10 +320,6 @@ case "$DETECTED_DOC_TYPE" in
         if [ -n "$ENABLE_PROTECTION" ]; then
             DOCKER_ENV_VARS="$DOCKER_ENV_VARS -e ENABLE_PROTECTION=$ENABLE_PROTECTION"
         fi
-        # Registry Manager連携設定が環境変数で指定されている場合は渡す
-        if [ -n "$ENABLE_REGISTRY_MANAGER" ]; then
-            DOCKER_ENV_VARS="$DOCKER_ENV_VARS -e ENABLE_REGISTRY_MANAGER=$ENABLE_REGISTRY_MANAGER"
-        fi
         ;;
     ise)
         # ISE固有の環境変数処理

--- a/create-repo/setup.sh
+++ b/create-repo/setup.sh
@@ -18,7 +18,12 @@ fi
 DOC_TYPE="${DOC_TYPE}"
 
 # 引数または環境変数から学籍番号を取得
-STUDENT_ID="${1:-$STUDENT_ID}"
+# ただし、INDIVIDUAL_MODE=trueかつDOC_TYPE=latexの場合はスキップ
+if [ "${INDIVIDUAL_MODE:-false}" = "true" ] && [ "$DOC_TYPE" = "latex" ]; then
+    STUDENT_ID=""
+else
+    STUDENT_ID="${1:-$STUDENT_ID}"
+fi
 
 # 文書タイプの検証
 if [ -z "$DOC_TYPE" ]; then

--- a/create-repo/setup.sh
+++ b/create-repo/setup.sh
@@ -18,12 +18,7 @@ fi
 DOC_TYPE="${DOC_TYPE}"
 
 # 引数または環境変数から学籍番号を取得
-# ただし、INDIVIDUAL_MODE=trueかつDOC_TYPE=latexの場合はスキップ
-if [ "${INDIVIDUAL_MODE:-false}" = "true" ] && [ "$DOC_TYPE" = "latex" ]; then
-    STUDENT_ID=""
-else
-    STUDENT_ID="${1:-$STUDENT_ID}"
-fi
+STUDENT_ID="${1:-$STUDENT_ID}"
 
 # 文書タイプの検証
 if [ -z "$DOC_TYPE" ]; then
@@ -324,6 +319,10 @@ case "$DETECTED_DOC_TYPE" in
         # ブランチ保護設定が環境変数で指定されている場合は渡す
         if [ -n "$ENABLE_PROTECTION" ]; then
             DOCKER_ENV_VARS="$DOCKER_ENV_VARS -e ENABLE_PROTECTION=$ENABLE_PROTECTION"
+        fi
+        # Registry Manager連携設定が環境変数で指定されている場合は渡す
+        if [ -n "$ENABLE_REGISTRY_MANAGER" ]; then
+            DOCKER_ENV_VARS="$DOCKER_ENV_VARS -e ENABLE_REGISTRY_MANAGER=$ENABLE_REGISTRY_MANAGER"
         fi
         ;;
     ise)

--- a/docs/CLAUDE-EXAMPLES.md
+++ b/docs/CLAUDE-EXAMPLES.md
@@ -16,6 +16,24 @@ STUDENT_ID=k21rs001 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com
 STUDENT_ID=k21rs001 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/smkwlab/thesis-management-tools/main/create-repo/setup-wr.sh)"
 ```
 
+### Universal Setup Script with Document Types
+```bash
+# Thesis repository
+DOC_TYPE=thesis STUDENT_ID=k21rs001 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/smkwlab/thesis-management-tools/main/create-repo/setup.sh)"
+
+# Weekly reports
+DOC_TYPE=wr STUDENT_ID=k21rs001 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/smkwlab/thesis-management-tools/main/create-repo/setup.sh)"
+
+# General LaTeX documents (organization mode)
+DOC_TYPE=latex STUDENT_ID=k21rs001 DOCUMENT_NAME=research-note /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/smkwlab/thesis-management-tools/main/create-repo/setup.sh)"
+
+# General LaTeX documents (individual mode - no student ID required)
+INDIVIDUAL_MODE=true DOC_TYPE=latex DOCUMENT_NAME=my-paper /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/smkwlab/thesis-management-tools/main/create-repo/setup.sh)"
+
+# ISE reports
+DOC_TYPE=ise STUDENT_ID=k21rs001 ISE_REPORT_NUM=1 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/smkwlab/thesis-management-tools/main/create-repo/setup.sh)"
+```
+
 ### Advanced Usage
 ```bash
 # Debug mode for troubleshooting


### PR DESCRIPTION
## 概要

latex-templateを使用する際、学生以外のユーザー（教員、研究者、一般ユーザー）も利用できるよう、INDIVIDUAL_MODEで学籍番号の入力を不要にする機能を追加しました。

## 変更内容

### 1. `main-latex.sh`の改善
- `INDIVIDUAL_MODE=true`の場合、学籍番号の入力をスキップ
- リポジトリ名は単にドキュメント名のみ（例：`research-note`、`my-paper`）
- Registry Manager連携も学籍番号がある場合のみ実行

### 2. `setup.sh`の更新  
- `INDIVIDUAL_MODE=true`かつ`DOC_TYPE=latex`の場合、学籍番号を自動的に空に設定

### 3. ドキュメントの更新
- `CLAUDE.md`と`docs/CLAUDE-EXAMPLES.md`に新しい使用例を追加

## 使用例

### 個人モード（学籍番号不要）
```bash
INDIVIDUAL_MODE=true DOC_TYPE=latex DOCUMENT_NAME=my-paper /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/smkwlab/thesis-management-tools/main/create-repo/setup.sh)"
```
→ リポジトリ名：`my-paper`

### 従来の組織モード
```bash  
DOC_TYPE=latex STUDENT_ID=k21rs001 DOCUMENT_NAME=research-note /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/smkwlab/thesis-management-tools/main/create-repo/setup.sh)"
```
→ リポジトリ名：`k21rs001-research-note`

## 利点

- 教員や研究者が個人的なLaTeX文書を作成する際に便利
- 学籍番号という学生固有の概念に依存しない汎用的な利用が可能
- 既存の動作には影響しない（後方互換性を維持）

## テスト

- [x] 構文チェック（`bash -n`）でエラーなし
- [ ] 実際の動作確認（マージ後に実施予定）