### PR TITLE
Fix latex template repository to always use smkwlab/latex-template

### DIFF
--- a/create-repo/main-latex.sh
+++ b/create-repo/main-latex.sh
@@ -16,8 +16,8 @@ ENABLE_PROTECTION="${ENABLE_PROTECTION:-false}"
 # 組織設定
 ORGANIZATION=$(determine_organization)
 
-# テンプレートリポジトリの設定
-TEMPLATE_REPOSITORY="${ORGANIZATION}/latex-template"
+# テンプレートリポジトリの設定（常にsmkwlab/latex-templateを使用）
+TEMPLATE_REPOSITORY="smkwlab/latex-template"
 echo -e "${GREEN}✓ テンプレートリポジトリ: $TEMPLATE_REPOSITORY${NC}"
 
 # INDIVIDUAL_MODEの場合は学籍番号をスキップ


### PR DESCRIPTION
## Summary
- Fixed template repository selection in `main-latex.sh` to always use `smkwlab/latex-template`
- Previously, INDIVIDUAL_MODE incorrectly used personal account's template (e.g., `toshi0806/latex-template`)

## Problem
When using INDIVIDUAL_MODE, the template repository was incorrectly determined based on the ORGANIZATION variable, which could point to a personal account instead of the official smkwlab template.

## Solution
- Hardcoded the template repository to always be `smkwlab/latex-template`
- This ensures all users (both organization and individual mode) use the same official template

## Testing
```bash
# Individual mode should now use smkwlab/latex-template
INDIVIDUAL_MODE=true DOC_TYPE=latex DOCUMENT_NAME=my-paper /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/smkwlab/thesis-management-tools/main/create-repo/setup.sh)"
```