### PR TITLE
Fix Docker interactive mode issue for INDIVIDUAL_MODE with DOCUMENT_NAME

### DIFF
--- a/create-repo/setup.sh
+++ b/create-repo/setup.sh
@@ -344,15 +344,25 @@ if [[ -n "$MSYSTEM" ]] || [[ "$OSTYPE" == "msys" ]] || [[ -n "$MINGW_PREFIX" ]] 
     fi
 fi
 
+# 対話的入力が必要かどうかを判断
+DOCKER_OPTIONS="--rm"
+if [ "$DOC_TYPE" = "latex" ] && [ "$INDIVIDUAL_MODE" = "true" ] && [ -n "$DOCUMENT_NAME" ]; then
+    # INDIVIDUAL_MODEでDOCUMENT_NAMEが指定されている場合は非対話的モード
+    echo "📋 非対話的モードで実行（DOCUMENT_NAME: $DOCUMENT_NAME）"
+else
+    # その他の場合は対話的モード
+    DOCKER_OPTIONS="$DOCKER_OPTIONS -it"
+fi
+
 # 統一されたDocker実行（全タイプ共通）
 if [ -n "$STUDENT_ID" ]; then
-    if ! docker run --rm -it $DOCKER_ENV_VARS -v "$TOKEN_FILE:/tmp/gh_token:ro" "$DOCKER_IMAGE_NAME" "$STUDENT_ID"; then
+    if ! docker run $DOCKER_OPTIONS $DOCKER_ENV_VARS -v "$TOKEN_FILE:/tmp/gh_token:ro" "$DOCKER_IMAGE_NAME" "$STUDENT_ID"; then
         echo "❌ セットアップスクリプトの実行に失敗しました"
         echo "学籍番号: $STUDENT_ID"
         exit 1
     fi
 else
-    if ! docker run --rm -it $DOCKER_ENV_VARS -v "$TOKEN_FILE:/tmp/gh_token:ro" "$DOCKER_IMAGE_NAME"; then
+    if ! docker run $DOCKER_OPTIONS $DOCKER_ENV_VARS -v "$TOKEN_FILE:/tmp/gh_token:ro" "$DOCKER_IMAGE_NAME"; then
         echo "❌ セットアップスクリプトの実行に失敗しました"
         exit 1
     fi


### PR DESCRIPTION
## Summary
Fixed Docker container hanging issue when using INDIVIDUAL_MODE with environment variables.

## Problem
When running the setup script with all parameters provided via environment variables:
```bash
INDIVIDUAL_MODE=true DOC_TYPE=latex DOCUMENT_NAME=my-paper /bin/bash -c "$(curl -fsSL ...)"
```
The Docker container would hang because it was running with `-it` (interactive + TTY) options even though no user input was needed.

## Solution
- Added logic to detect when interactive mode is not needed
- Use non-interactive mode when:
  - `DOC_TYPE=latex`
  - `INDIVIDUAL_MODE=true`
  - `DOCUMENT_NAME` is provided via environment variable
- Keep interactive mode for all other cases where user input is expected

## Testing
```bash
# This should now work without hanging
INDIVIDUAL_MODE=true DOC_TYPE=latex DOCUMENT_NAME=my-paper /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/smkwlab/thesis-management-tools/main/create-repo/setup.sh)"
```

## Related Issues
- Fixes the Docker execution error reported when using INDIVIDUAL_MODE with environment variables