### PR TITLE
Fix INDIVIDUAL_MODE confirmation issue in confirm_creation function

### DIFF
--- a/create-repo/common-lib.sh
+++ b/create-repo/common-lib.sh
@@ -299,7 +299,10 @@ check_organization_membership() {
 check_organization_access() {
     local organization="$1"
     
-    [ "$INDIVIDUAL_MODE" = false ] && check_organization_membership "$organization" "$CURRENT_USER" || exit 1
+    # INDIVIDUAL_MODEが有効でない場合のみ組織メンバーシップをチェック
+    if ! [[ "$INDIVIDUAL_MODE" =~ ^(true|TRUE|1|yes|YES)$ ]]; then
+        check_organization_membership "$organization" "$CURRENT_USER" || exit 1
+    fi
 }
 
 # ================================
@@ -311,10 +314,10 @@ determine_repository_path() {
     local organization="$1"
     local repo_name="$2"
     
-    if [ "$INDIVIDUAL_MODE" = false ]; then
-        echo "${organization}/${repo_name}"
-    else
+    if [[ "$INDIVIDUAL_MODE" =~ ^(true|TRUE|1|yes|YES)$ ]]; then
         echo "${CURRENT_USER}/${repo_name}"
+    else
+        echo "${organization}/${repo_name}"
     fi
 }
 
@@ -326,8 +329,8 @@ confirm_creation() {
     echo -e "${BRIGHT_WHITE}🎯 作成予定リポジトリ: $repo_path${NC}"
     echo ""
     
-    # INDIVIDUAL_MODEの場合は自動承認
-    if [ "$INDIVIDUAL_MODE" = "true" ]; then
+    # INDIVIDUAL_MODEの場合は自動承認（柔軟な値判定）
+    if [[ "$INDIVIDUAL_MODE" =~ ^(true|TRUE|1|yes|YES)$ ]]; then
         echo "📋 個人モード: 自動的に続行します"
         return 0
     fi

--- a/create-repo/common-lib.sh
+++ b/create-repo/common-lib.sh
@@ -325,6 +325,13 @@ confirm_creation() {
     echo ""
     echo -e "${BRIGHT_WHITE}🎯 作成予定リポジトリ: $repo_path${NC}"
     echo ""
+    
+    # INDIVIDUAL_MODEの場合は自動承認
+    if [ "$INDIVIDUAL_MODE" = "true" ]; then
+        echo "📋 個人モード: 自動的に続行します"
+        return 0
+    fi
+    
     read -p "続行しますか? [Y/n]: " -n 1 -r
     echo ""
     

--- a/create-repo/main-latex.sh
+++ b/create-repo/main-latex.sh
@@ -20,8 +20,8 @@ ORGANIZATION=$(determine_organization)
 TEMPLATE_REPOSITORY="smkwlab/latex-template"
 echo -e "${GREEN}✓ テンプレートリポジトリ: $TEMPLATE_REPOSITORY${NC}"
 
-# INDIVIDUAL_MODEの場合は学籍番号をスキップ
-if [ "$INDIVIDUAL_MODE" = true ]; then
+# INDIVIDUAL_MODEの場合は学籍番号をスキップ（柔軟な値判定）
+if [[ "$INDIVIDUAL_MODE" =~ ^(true|TRUE|1|yes|YES)$ ]]; then
     echo -e "${BLUE}📝 個人モード: 学籍番号の入力をスキップします${NC}"
     STUDENT_ID=""
 else
@@ -56,8 +56,8 @@ read_document_name() {
 
 read_document_name
 
-# リポジトリ名の決定
-if [ "$INDIVIDUAL_MODE" = true ]; then
+# リポジトリ名の決定（柔軟な値判定）
+if [[ "$INDIVIDUAL_MODE" =~ ^(true|TRUE|1|yes|YES)$ ]]; then
     REPO_NAME="${DOCUMENT_NAME}"
 else
     REPO_NAME="${STUDENT_ID}-${DOCUMENT_NAME}"
@@ -105,7 +105,8 @@ commit_and_push "Initial customization for ${DOCUMENT_NAME}
 
 # Registry Manager連携（組織ユーザーのみ、かつ学籍番号がある場合）
 # 条件: 個人モードが無効 AND 学籍番号が存在 AND Registryリポジトリがアクセス可能
-if [ "$INDIVIDUAL_MODE" = false ] && [ -n "$STUDENT_ID" ] && gh repo view "${ORGANIZATION}/thesis-student-registry" &>/dev/null; then
+# INDIVIDUAL_MODEが有効でない場合のみRegistry Manager連携
+if ! [[ "$INDIVIDUAL_MODE" =~ ^(true|TRUE|1|yes|YES)$ ]] && [ -n "$STUDENT_ID" ] && gh repo view "${ORGANIZATION}/thesis-student-registry" &>/dev/null; then
     if ! create_repository_issue "$REPO_NAME" "$STUDENT_ID" "latex" "$ORGANIZATION"; then
         echo -e "${YELLOW}⚠️ Registry Manager登録でエラーが発生しました。手動で登録が必要な場合があります。${NC}"
     fi

--- a/create-repo/setup.sh
+++ b/create-repo/setup.sh
@@ -180,7 +180,7 @@ detect_user_type() {
     fi
     
     # INDIVIDUAL_MODE環境変数による明示的指定
-    if [ "${INDIVIDUAL_MODE:-false}" = "true" ]; then
+    if [[ "${INDIVIDUAL_MODE:-false}" =~ ^(true|TRUE|1|yes|YES)$ ]]; then
         echo "individual_user"
         return 0
     fi
@@ -346,7 +346,7 @@ fi
 
 # 対話的入力が必要かどうかを判断
 DOCKER_OPTIONS="--rm"
-if [ "$DOC_TYPE" = "latex" ] && [ "$INDIVIDUAL_MODE" = "true" ] && [ -n "$DOCUMENT_NAME" ]; then
+if [ "$DOC_TYPE" = "latex" ] && [[ "$INDIVIDUAL_MODE" =~ ^(true|TRUE|1|yes|YES)$ ]] && [ -n "$DOCUMENT_NAME" ]; then
     # INDIVIDUAL_MODEでDOCUMENT_NAMEが指定されている場合は非対話的モード
     echo "📋 非対話的モードで実行（DOCUMENT_NAME: $DOCUMENT_NAME）"
 else


### PR DESCRIPTION
## Summary
INDIVIDUAL_MODEでのsetup.sh実行失敗を修正

## Problem
INDIVIDUAL_MODEで実行時、`confirm_creation`関数の`read`コマンドで対話的入力を待機し、非対話的Dockerコンテナ内でハングしていました。

## Solution
- INDIVIDUAL_MODE=trueの場合、確認プロンプトを自動承認
- 「個人モード: 自動的に続行します」メッセージを表示
- 対話的入力をスキップして処理を継続

## Testing
```bash
# この問題が修正されているはずです
INDIVIDUAL_MODE=true DOC_TYPE=latex /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/smkwlab/thesis-management-tools/main/create-repo/setup.sh)"
```

## Root Cause
`confirm_creation`関数が組織モード向けに設計されていたため、個人モードでも対話的確認を要求していました。個人モードでは自動承認が適切です。