### PR TITLE
Include auto-assign files in main branch commit

### DIFF
--- a/create-repo/main-ise.sh
+++ b/create-repo/main-ise.sh
@@ -189,6 +189,7 @@ setup_auto_assign_for_organization_members
 
 # main ブランチでの初期セットアップコミット
 git add -u
+git add .github/ 2>/dev/null || true
 git commit -m "Initial setup for ISE Report #${ISE_REPORT_NUM}" >/dev/null 2>&1 || true
 
 if git push origin main >/dev/null 2>&1; then

--- a/create-repo/main-thesis.sh
+++ b/create-repo/main-thesis.sh
@@ -102,6 +102,7 @@ setup_auto_assign_for_organization_members
 
 # main ブランチでの初期セットアップコミット
 git add -u
+git add .github/ 2>/dev/null || true
 git commit -m "Initial setup for ${THESIS_TYPE}" >/dev/null 2>&1 || true
 
 if git push origin main >/dev/null 2>&1; then


### PR DESCRIPTION
## Summary

Fix auto-assign configuration files leaking into 0th-draft branch commits by explicitly staging `.github/` directory in the main branch commit.

## Problem

Currently, auto-assign files appear in the 0th-draft branch commit instead of the main branch commit because:

1. `setup_auto_assign_for_organization_members()` creates new files in `.github/`
2. `git add -u` only stages **modified** files, not new files
3. Auto-assign files remain unstaged after main branch commit
4. When 0th-draft branch is created from main, these unstaged files are committed there

## Solution

Add `git add .github/` before the main branch commit to explicitly stage newly created auto-assign files:

```bash
git add -u
git add .github/ 2>/dev/null || true  # <-- Add this line
git commit -m "Initial setup for ${THESIS_TYPE}"
```

The `2>/dev/null || true` ensures the command doesn't fail if `.github/` doesn't exist (e.g., for external users).

## Changes

- **main-thesis.sh**: Add `git add .github/` before main branch commit
- **main-ise.sh**: Add `git add .github/` before main branch commit

## Testing

After this fix:
- ✅ Auto-assign files will be committed to main branch (organization members only)
- ✅ 0th-draft branch commits will be clean (no auto-assign files)
- ✅ External users unaffected (no `.github/` directory created)

## Related

- Follow-up to #345, #346, #347 (secure-by-default architecture)