### PR TITLE
Remove example files for master thesis setup

### DIFF
--- a/create-repo/main-thesis.sh
+++ b/create-repo/main-thesis.sh
@@ -88,9 +88,9 @@ find . -name '*-aldc' -exec rm -rf {} + 2>/dev/null || true
 
 # 論文タイプに応じて不要なファイルを削除
 if [ "$THESIS_TYPE" = "shuuron" ]; then
-    # 修士論文: sotsuron.tex, gaiyou.tex を削除
-    rm -f sotsuron.tex gaiyou.tex 2>/dev/null || true
-    echo "修士論文用: sotsuron.tex, gaiyou.tex を削除しました"
+    # 修士論文: sotsuron.tex, gaiyou.tex, example.tex, example-gaiyou.tex を削除
+    rm -f sotsuron.tex gaiyou.tex example.tex example-gaiyou.tex 2>/dev/null || true
+    echo "修士論文用: sotsuron.tex, gaiyou.tex, example.tex, example-gaiyou.tex を削除しました"
 elif [ "$THESIS_TYPE" = "sotsuron" ]; then
     # 卒業論文: thesis.tex, abstract.tex を削除
     rm -f thesis.tex abstract.tex 2>/dev/null || true


### PR DESCRIPTION
## Summary

Remove example.tex and example-gaiyou.tex during master thesis (shuuron) repository setup, as these example files are only needed for undergraduate thesis.

## Changes

- Add `example.tex` and `example-gaiyou.tex` to the removal list for master thesis
- Update echo message to reflect the additional file removals

## Motivation

Example files (example.tex, example-gaiyou.tex) are provided for undergraduate students to learn LaTeX formatting. Graduate students working on master theses don't need these example files and should start with clean thesis.tex and abstract.tex files.

## Current behavior vs New behavior

**Before:**
- Master thesis repos included example.tex and example-gaiyou.tex
- These files were not relevant for graduate students

**After:**
- Master thesis repos only include thesis.tex and abstract.tex
- Cleaner repository structure for graduate students