### PR TITLE
Create shared GitHub CLI installation guide and refactor template READMEs

### DIFF
--- a/docs/INSTALL-GH.md
+++ b/docs/INSTALL-GH.md
@@ -1,0 +1,64 @@
+# GitHub CLI (gh) のインストール
+
+GitHub CLI は、リポジトリ作成スクリプト (`setup.sh`) の実行に必要なツールです。
+
+## macOS
+
+Homebrew を使用してインストール：
+
+```bash
+brew install gh
+```
+
+## Windows (WSL)
+
+WSL (Ubuntu/Debian) 内で公式リポジトリからインストール：
+
+```bash
+# 公式リポジトリのセットアップ
+sudo mkdir -p -m 755 /etc/apt/keyrings
+wget -qO- https://cli.github.com/packages/githubcli-archive-keyring.gpg | sudo tee /etc/apt/keyrings/githubcli-archive-keyring.gpg > /dev/null
+sudo chmod go+r /etc/apt/keyrings/githubcli-archive-keyring.gpg
+echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null
+
+# インストール
+sudo apt update
+sudo apt install gh
+```
+
+**注意**: Windows では WSL 内で全ての操作を実行してください。
+
+## インストール確認
+
+```bash
+gh --version
+```
+
+バージョン情報が表示されればインストール成功です。
+
+## 認証
+
+```bash
+gh auth login
+```
+
+### 認証手順
+
+1. `GitHub.com` を選択
+2. `HTTPS` を選択
+3. `Login with a web browser` を選択
+4. 表示されたワンタイムコードをコピー
+5. ブラウザが自動で開くので、コードを入力して認証完了
+
+### 認証確認
+
+```bash
+gh auth status
+```
+
+`Logged in to github.com` と表示されれば認証成功です。
+
+## 参考
+
+- [GitHub CLI 公式サイト](https://cli.github.com/)
+- [GitHub CLI ドキュメント](https://cli.github.com/manual/)


### PR DESCRIPTION
## Summary

Resolves #376

GitHub CLI (gh) のインストール手順を共通ドキュメント化し、各テンプレートリポジトリの README を簡素化しました。

## Changes

### 1. 共通ドキュメント作成

`docs/INSTALL-GH.md` を作成：
- macOS: Homebrew でのインストール
- Windows (WSL): 公式リポジトリセットアップ
- 認証手順: `gh auth login`
- インストール確認手順

### 2. 各テンプレート README 簡素化

以下の5つのテンプレートリポジトリで README を更新：
- **sotsuron-template** (PR #99)
- **wr-template** (PR #33)
- **latex-template** (PR #17)
- **ise-report-template** (PR #18)
- **poster-template** (PR #14)

#### 変更内容
- 前提条件に GitHub CLI (gh) を明記
- 詳細なインストール手順を削除し、`INSTALL-GH.md` へのリンクに変更
- 準備セクションを `gh auth login` のみのシンプルな形式に変更
- setup.sh の実行が目立つ構成に変更

## Benefits

1. **DRY原則**: インストール手順を一箇所で管理
2. **保守性**: 更新時に全リポジトリを変更する必要がない
3. **明確性**: setup.sh の実行が目立ち、本来の目的が明確
4. **一貫性**: 全テンプレートで同じ情報を提供

## Related PRs

- smkwlab/sotsuron-template#99
- smkwlab/wr-template#33
- smkwlab/latex-template#17
- smkwlab/ise-report-template#18
- smkwlab/poster-template#14