### PR TITLE
Fix enforce_admins setting using correct GitHub API endpoint

### DIFF
--- a/scripts/setup-branch-protection.sh
+++ b/scripts/setup-branch-protection.sh
@@ -114,7 +114,7 @@ verify_admin_permissions() {
 setup_enforce_admins() {
     local repo_name="$1"
     local enforce="$2"  # true or false
-    local branch="${3:-main}"
+    local branch="${3:-main}"  # 将来の拡張用（複数ブランチ対応）
 
     log "enforce_admins 設定: $enforce (branch: $branch)"
 
@@ -294,7 +294,10 @@ setup_protection() {
 
         # enforce_admins を false に設定（学生リポジトリでは管理者が直接操作できるようにする）
         # 注: テンプレートリポジトリでは true を設定すべきだが、このスクリプトは学生リポジトリ用
-        setup_enforce_admins "$repo_name" "false"
+        if ! setup_enforce_admins "$repo_name" "false"; then
+            error "❌ enforce_admins 設定に失敗しました"
+            return 1
+        fi
 
         # 学生リストの更新（pending → completed）
         update_student_lists "$repo_name"


### PR DESCRIPTION
## 概要

`enforce_admins` 設定が正しく適用されていなかった問題を修正します。

Fixes #391

## 問題

GitHub API では `enforce_admins` は別のエンドポイントで設定する必要がありますが、従来のコードでは一括設定の JSON に含めていたため、設定が無視されていました。

## 変更内容

### 1. `setup_enforce_admins()` 関数を追加

```bash
# 正しい API エンドポイントを使用
POST .../protection/enforce_admins   # enable (true)
DELETE .../protection/enforce_admins # disable (false)
```

### 2. 学生リポジトリでは `enforce_admins: false` を設定

学生リポジトリでは管理者がブランチプロテクションを回避できるようにしました。

**理由:**
- 教員が緊急時に直接修正可能
- 管理タスク（ワークフロー削除など）が容易
- PRレビュー要件は学生に対してのみ適用されれば目的達成

## テスト結果

```
$ ./scripts/setup-branch-protection.sh k22rs005-sotsuron
...
[SUCCESS] ✅ enforce_admins: false を設定しました（管理者は保護ルールを回避可能）
...

$ gh api repos/smkwlab/k22rs005-sotsuron/branches/main/protection/enforce_admins --jq '.enabled'
false
```

## 今後の課題

テンプレートリポジトリ（sotsuron-template 等）では `enforce_admins: true` を設定すべきですが、これは別の Issue で対応予定です。