### PR TITLE
Update ai-reviewer version to @v1

### DIFF
--- a/.github/workflows/ai-reviewer.yml
+++ b/.github/workflows/ai-reviewer.yml
@@ -21,7 +21,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Gemini Review Bot
-        uses: toshi0806/ai-reviewer@v1.3
+        uses: toshi0806/ai-reviewer@v1
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}


### PR DESCRIPTION
## Summary
- Change version from `@v1.3` to `@v1` (auto-update to latest v1.x)

## Changes
- Updated version reference for automatic updates within major version
- Will automatically use default model `gemini-2.5-flash` (updated in toshi0806/ai-reviewer)