### PR TITLE
Fix SCRIPT_DIR path resolution after cd

### DIFF
--- a/create-repo/common-lib.sh
+++ b/create-repo/common-lib.sh
@@ -5,6 +5,10 @@
 # 設定・定数
 # ================================
 
+# スクリプトディレクトリを読み込み時に確定（cd後でも正しいパスを参照できるように）
+# 注: source で読み込まれた場合、${BASH_SOURCE[0]} はこのファイルのパス
+SCRIPT_DIR="${SCRIPT_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
+
 # 色定義
 readonly RED='\033[0;31m'
 readonly GREEN='\033[0;32m'


### PR DESCRIPTION
## Summary
- `common-lib.sh` 読み込み時に `SCRIPT_DIR` を確定するよう修正
- `cd "$REPO_NAME"` 実行後も正しい templates/ パスを参照可能に

## Problem
ISE リポジトリ作成時に以下のエラーが発生:
```
❌ テンプレートディレクトリが見つかりません: /workspace/k18rs509-ise-report2/templates
```

## Cause
`setup_auto_assign_for_organization_members` 関数で `${BASH_SOURCE[0]}` が相対パス (`./common-lib.sh`) の場合、`run_standard_setup` 内の `cd "$REPO_NAME"` 実行後は間違った場所を参照していた。

## Solution
`common-lib.sh` の先頭で `SCRIPT_DIR` を確定することで、後から cd しても正しいパスを維持。

## Test plan
- [x] k18rs509 アカウントで `UNIVERSAL_BRANCH=fix-script-dir-path` を指定して ise リポジトリ作成成功を確認