### PR TITLE
Default to private visibility for latex and poster templates

### DIFF
--- a/create-repo/main-latex.sh
+++ b/create-repo/main-latex.sh
@@ -12,7 +12,7 @@ init_script_common "汎用LaTeXリポジトリセットアップツール" "📝
 # 設定
 ORGANIZATION=$(determine_organization)
 TEMPLATE_REPOSITORY="smkwlab/latex-template"  # 常に固定
-VISIBILITY="public"
+VISIBILITY="private"
 
 log_info "テンプレートリポジトリ: $TEMPLATE_REPOSITORY"
 

--- a/create-repo/main-poster.sh
+++ b/create-repo/main-poster.sh
@@ -12,7 +12,7 @@ init_script_common "学会ポスターリポジトリセットアップツール
 # 設定
 ORGANIZATION=$(determine_organization)
 TEMPLATE_REPOSITORY="smkwlab/poster-template"  # 常に固定
-VISIBILITY="public"
+VISIBILITY="private"
 
 log_info "テンプレートリポジトリ: $TEMPLATE_REPOSITORY"
 


### PR DESCRIPTION
## Summary
`latex-template` および `poster-template` から作成されるリポジトリのデフォルト visibility を `public` → `private` に変更します。

## Background
現状の各テンプレートの visibility 設定:

| テンプレート | 変更前 | 変更後 |
|---|---|---|
| sotsuron-template (卒論・修論) | private | private |
| wr-template (週報) | private | private |
| ise-report-template (ISE) | private | private |
| **latex-template (汎用)** | **public** | **private** |
| **poster-template (ポスター)** | **public** | **private** |

## Rationale
- 学生の作業ドラフトが意図せず公開されるリスクを回避
- 他テンプレート（卒論・週報・ISE）と挙動を統一
- 公開したい場合は学生が手動で visibility を変更可能（逆方向の変更は手戻りが大きい）

## Trade-off
- private リポジトリは GitHub Actions 分数を organization のクォータから消費する（public は無制限）
- 利用件数を考慮しても許容範囲と判断

## Files Changed
- `create-repo/main-latex.sh`: `VISIBILITY="public"` → `"private"`
- `create-repo/main-poster.sh`: `VISIBILITY="public"` → `"private"`