### PR TITLE
Fix cleanup of leftover *-aldc files to run after aldc execution

### DIFF
--- a/create-repo/common-lib.sh
+++ b/create-repo/common-lib.sh
@@ -548,6 +548,28 @@ setup_latex_environment() {
     fi
 }
 
+# テンプレートファイルの整理
+#
+# 自動生成リポジトリに不要なファイルを削除します。
+# - CLAUDE.md      : テンプレート／latex-environment 由来の開発者向け説明（学生リポジトリには不要）
+# - docs/          : テンプレート／latex-environment 由来のドキュメント
+# - *-aldc         : aldc が統合時に生成する衝突ファイルのバックアップ
+#
+# 重要: この関数は aldc 実行（setup_latex_environment）の **後** に呼ぶ必要があります。
+# aldc は latex-environment 由来の CLAUDE.md / docs/ を持ち込み、既存ファイルと衝突した
+# 場合は <元ファイル名>-aldc としてバックアップを残すため、aldc 実行前に削除しても
+# これらは再生成・残存してしまいます（Issue #433）。
+#
+# 戻り値:
+#   0 - 常に成功
+cleanup_template_files() {
+    log_info "テンプレートファイルを整理中..."
+    rm -f CLAUDE.md 2>/dev/null || true
+    rm -rf docs/ 2>/dev/null || true
+    find . -name '*-aldc' -exec rm -rf {} + 2>/dev/null || true
+    return 0
+}
+
 # smkwlab 組織メンバー用の auto-assign 設定追加
 #
 # 組織メンバーの場合のみ、PR自動レビュワー割り当て設定を追加します。
@@ -688,11 +710,10 @@ run_standard_setup() {
     setup_git_auth || exit 1
     setup_git_user "setup-${doc_type}@smkwlab.github.io" "${display_name} Setup Tool"
 
-    # 共通ファイル整理
-    echo "テンプレートファイルを整理中..."
-    rm -f CLAUDE.md 2>/dev/null || true
-    rm -rf docs/ 2>/dev/null || true
-    find . -name '*-aldc' -exec rm -rf {} + 2>/dev/null || true
+    # 注意: テンプレートファイルの整理（CLAUDE.md / docs/ / *-aldc 削除）は
+    # ここでは行わない。aldc（setup_latex_environment）が latex-environment 由来の
+    # CLAUDE.md / docs/ を持ち込み、衝突ファイルを *-aldc として生成するため、
+    # 整理は aldc 実行後に cleanup_template_files() で行う必要がある（Issue #433）。
 }
 
 #

--- a/create-repo/main-ise.sh
+++ b/create-repo/main-ise.sh
@@ -148,6 +148,10 @@ setup_auto_assign_for_organization_members
 # 組織外ユーザーの場合は組織専用ワークフローを削除
 remove_org_specific_workflows
 
+# テンプレートファイルの整理（ISE は aldc 非実行のため *-aldc は無いが、
+# テンプレート由来の CLAUDE.md / docs/ を削除する: Issue #433）
+cleanup_template_files
+
 # main ブランチでの初期セットアップコミット
 git add -u
 git add .github/ 2>/dev/null || true

--- a/create-repo/main-latex.sh
+++ b/create-repo/main-latex.sh
@@ -65,6 +65,9 @@ setup_latex_environment
 # 組織外ユーザーの場合は組織専用ワークフローを削除
 remove_org_specific_workflows
 
+# テンプレートファイルの整理（aldc 実行後に行う必要がある: Issue #433）
+cleanup_template_files
+
 # 変更をコミットしてプッシュ
 commit_and_push "Initial customization for ${DOCUMENT_NAME}
 

--- a/create-repo/main-poster.sh
+++ b/create-repo/main-poster.sh
@@ -74,6 +74,9 @@ setup_latex_environment
 # 組織外ユーザーの場合は組織専用ワークフローを削除
 remove_org_specific_workflows
 
+# テンプレートファイルの整理（aldc 実行後に行う必要がある: Issue #433）
+cleanup_template_files
+
 # 変更をコミットしてプッシュ
 commit_and_push "Initial setup for ${POSTER_NAME}
 

--- a/create-repo/main-thesis.sh
+++ b/create-repo/main-thesis.sh
@@ -75,6 +75,9 @@ setup_auto_assign_for_organization_members
 # 組織外ユーザーの場合は組織専用ワークフローを削除
 remove_org_specific_workflows
 
+# テンプレートファイルの整理（aldc 実行後に行う必要がある: Issue #433）
+cleanup_template_files
+
 # main ブランチでの初期セットアップコミット
 git add -u
 git add .github/ 2>/dev/null || true

--- a/create-repo/main-wr.sh
+++ b/create-repo/main-wr.sh
@@ -43,6 +43,9 @@ setup_latex_environment
 # 組織外ユーザーの場合は組織専用ワークフローを削除
 remove_org_specific_workflows
 
+# テンプレートファイルの整理（aldc 実行後に行う必要がある: Issue #433）
+cleanup_template_files
+
 # 変更をコミットしてプッシュ
 if [[ "$INDIVIDUAL_MODE" =~ ^(true|TRUE|1|yes|YES)$ ]]; then
     commit_and_push "Initialize weekly report repository


### PR DESCRIPTION
## 概要

セットアップスクリプト実行後、生成されたリポジトリに `*-aldc` や latex-environment 由来の `CLAUDE.md` / `docs/` が残存する問題を修正します。

resolve #433

## 問題の原因

`run_standard_setup()`(`common-lib.sh`)末尾のクリーンアップ処理が、`setup_latex_environment()`(aldc 実行)**より前**に走っていました。

- aldc は統合時に衝突ファイルを `<元ファイル名>-aldc` として生成するため、aldc 実行前に `find . -name '*-aldc' -delete` しても削除対象がまだ存在しない。
- さらに `latex-environment` には `CLAUDE.md` / `docs/` が含まれており、aldc がこれらを**新規コピー**で持ち込むため、aldc 実行前に削除しても復活する。

結果として、クリーンアップコードがあるにもかかわらず**実質的に機能していない**状態でした。

### 実際の残存例(調査時点)
- `k23rs134-wr`: `CLAUDE.md` 残存
- `k26gjk01-wr`: `.gitignore-aldc`, `.latexmkrc-aldc`, `.textlintrc-aldc` 残存

## 修正内容

- クリーンアップ処理を専用関数 `cleanup_template_files()`(`common-lib.sh`)に切り出し
- `run_standard_setup()` からは整理処理を削除し、その旨をコメントで明記
- 各 `main-*.sh` で aldc 実行後(`remove_org_specific_workflows` の直後、commit の前)に `cleanup_template_files` を呼び出し
  - `main-thesis.sh` / `main-wr.sh` / `main-latex.sh` / `main-poster.sh`: aldc 実行後に整理
  - `main-ise.sh`: aldc 非実行のため `*-aldc` は無いが、テンプレート由来の `CLAUDE.md` / `docs/` 削除を維持

## 設計方針

Issue で挙げられた選択肢のうち、**thesis-management-tools 側で対応**を採用。`CLAUDE.md` / `docs/` の削除は本リポジトリ固有の要件であり、汎用ツールである aldc には手を入れず本リポジトリに閉じる形が自然なため。

## テスト

- `bash -n` で全 6 ファイルの構文チェック: OK
- `shellcheck`: 今回の追加分に新規警告なし(既存警告のみ)
- 一時ディレクトリで `cleanup_template_files()` の動作検証: `CLAUDE.md` / `docs/` / `*-aldc` が削除され、必要ファイル(`main.tex`)は残存することを確認