### PR TITLE
Use shared Renovate preset from smkwlab/.github

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,32 +1,4 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "dependencyDashboard": true,
-  "dependencyDashboardLabels": ["dependencies"],
-  "extends": ["config:recommended", "workarounds:all"],
-  "timezone": "Asia/Tokyo",
-  "schedule": ["after 9pm on sunday"],
-  "semanticCommits": "enabled",
-  "packageRules": [
-    {
-      "description": "GitHub Actions version updates",
-      "matchManagers": ["github-actions"],
-      "pinDigests": true,
-      "labels": ["dependencies", "github-actions"],
-      "semanticCommitType": "ci"
-    },
-    {
-      "description": "Docker base image updates",
-      "matchManagers": ["dockerfile"],
-      "pinDigests": true,
-      "labels": ["dependencies", "docker"],
-      "semanticCommitType": "build"
-    },
-    {
-      "description": "npm dependency updates",
-      "matchManagers": ["npm"],
-      "labels": ["dependencies", "npm"],
-      "rangeStrategy": "bump",
-      "semanticCommitType": "chore"
-    }
-  ]
+  "extends": ["github>smkwlab/.github:latex"]
 }

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,4 +1,4 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["github>smkwlab/.github:latex"]
+  "extends": ["github>smkwlab/.github:latex#v1"]
 }


### PR DESCRIPTION
## Summary

Replace the duplicated Renovate configuration with a one-line `extends` of the org-wide shared preset.

```jsonc
{
  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
  "extends": ["github>smkwlab/.github:latex"]
}
```

The previous config (github-actions/docker `pinDigests`, npm `bump`, weekly Sunday schedule, `workarounds:all`) is now defined centrally in `smkwlab/.github` (`default.json` + `latex.json`), so behavior is preserved. In addition, patch/digest auto-merge is now applied per the shared org policy.

## Context

Part of the ecosystem-wide Renovate consolidation. Shared presets were added in smkwlab/.github#28 (merged). This is one of the latex-ecosystem repos migrating to the shared preset.
