### PR TITLE
Document v1 moving major tag for template pinning

### DIFF
--- a/create-repo/README.md
+++ b/create-repo/README.md
@@ -61,7 +61,7 @@ STUDENT_ID=k21rs001 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com
 
 - スクリプトの内容は公開リポジトリでいつでも確認できます。実行前に内容を確認したい場合は、
   上記 URL をブラウザで開いて確認してください。
-- 利用可能なバージョンは [Releases](https://github.com/smkwlab/thesis-management-tools/releases) を参照してください。
+- 利用可能なバージョン（`v1.0.0` などの具体的なリリース）は [Releases](https://github.com/smkwlab/thesis-management-tools/releases) を参照してください。なお `v1` はそれらの最新を指す移動タグ（ポインタ）であり、Releases 一覧には個別の項目としては現れません。
 - リリース運用の詳細は [docs/RELEASE.md](../docs/RELEASE.md) を参照してください。
 
 ## よくある質問

--- a/create-repo/README.md
+++ b/create-repo/README.md
@@ -40,13 +40,20 @@ STUDENT_ID=k21rs001 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com
 スクリプトを取得します。ある時点の手順を確実に再現したい場合や、内容を固定して
 実行したい場合は、**タグ（バージョン）で固定した版**を利用できます。
 
-`setup.sh` の URL のブランチ部分（`main`）をタグ（例: `v1.0.0`）に変えるだけで、
-スクリプト本体・内部で取得する内容ともに同じバージョンに固定されます
-（文書タイプ引数の指定方法はこれまでと同じで、以下は論文 `thesis` の例です）。
+`setup.sh` の URL のブランチ部分（`main`）をタグに変えるだけで、スクリプト本体・
+内部で取得する内容ともに同じバージョンに固定されます（文書タイプ引数の指定方法は
+これまでと同じで、以下は論文 `thesis` の例です）。
 
 ```bash
+# 最新の v1 系（移動タグ。安定版を使いたい場合の推奨。テンプレート README もこちら）
+/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/smkwlab/thesis-management-tools/v1/create-repo/setup.sh)" bash thesis
+
+# 特定パッチに完全固定（厳密な再現が必要な場合）
 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/smkwlab/thesis-management-tools/v1.0.0/create-repo/setup.sh)" bash thesis
 ```
+
+> `v1` は「最新の v1 系リリース」を指す移動タグです（GitHub Actions の `@v4` と同様）。
+> 完全に同一の内容を再現したい場合は `v1.0.0` のように具体的なバージョンを指定してください。
 
 > 変更するのは **URL 内の `main` の部分だけ**です。コマンド末尾の引数（上の例では
 > `bash thesis`。`bash` は `bash -c` のダミー引数 `$0`、`thesis` が実際の文書タイプ `$1`）や、

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -72,7 +72,9 @@ git branch -D release-v1.0.0
 gh release create v1.0.0 --title "v1.0.0" --notes "リリース内容..."
 
 # 7. メジャー移動タグ v1 を当該リリースに合わせる（下記「メジャー移動タグ」参照）
-git tag -f v1 v1.0.0
+#    vX.Y.Z は annotated tag のため、^{} でコミットへ剥がして軽量タグにする
+#    （v1 がタグオブジェクトを指すと解決が不安定になるのを防ぐ）
+git tag -f v1 v1.0.0^{}
 git push origin v1 --force
 ```
 
@@ -103,13 +105,15 @@ git push origin v1 --force
 ### 運用ルール
 
 - **パッチ／マイナー**（`v1.0.1`, `v1.1.0` など）: 上記リリース手順の最後に
-  `git tag -f v1 vX.Y.Z && git push origin v1 --force` で `v1` を前進させる。
+  `git tag -f v1 vX.Y.Z^{} && git push origin v1 --force` で `v1` を前進させる
+  （`^{}` で annotated tag をコミットへ剥がし、`v1` を必ずコミットに向ける）。
 - **メジャー**（`v2.0.0`）: 新しい移動タグ `v2` を作成し、利用側テンプレートの
   README コマンド例を `/v1/` → `/v2/` に更新する（旧 `v1` は据え置きで互換維持）。
 
 ```bash
 # 例: v1 系の新リリース vX.Y.Z 後に v1 を前進させる
-git tag -f v1 vX.Y.Z
+# ^{} で annotated tag をコミットへ剥がし、v1 が必ずリリースコミットを指すようにする
+git tag -f v1 vX.Y.Z^{}
 git push origin v1 --force
 ```
 

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -70,11 +70,48 @@ git branch -D release-v1.0.0
 
 # 6. GitHub Release を作成（リリースノートを添付）
 gh release create v1.0.0 --title "v1.0.0" --notes "リリース内容..."
+
+# 7. メジャー移動タグ v1 を当該リリースに合わせる（下記「メジャー移動タグ」参照）
+git tag -f v1 v1.0.0
+git push origin v1 --force
 ```
 
 > **重要**: リリース用コミット（`EMBEDDED_REF="v1.0.0"`）を `main` にマージしないこと。
 > マージすると `main` の `setup.sh` が古いタグを指し続けてしまう。
 > `main` 上の `EMBEDDED_REF` は常に `"main"` を保つ。
+
+## メジャー移動タグ（`v1` など）
+
+利用側テンプレート（`sotsuron-template` 等）のコマンド例は、安定したメジャー系列を
+指す**移動タグ** `vN`（例: `v1`）を参照する（GitHub Actions の `@v4` と同じ考え方）。
+
+- `vN` は「その時点の最新の `vN.*.*` リリース」を指す。リリースのたびに最新へ動かす。
+- これにより、パッチ／マイナーリリースのたびに各テンプレートの README を更新する必要が
+  なくなる。**README の更新が必要になるのはメジャー更新（`v1` → `v2`）のときだけ**。
+- `vN` は単なるポインタ用タグであり、GitHub Release は作らない（Release は `vX.Y.Z` のみ）。
+
+### 二段固定との関係
+
+`vN` は「どのリリースコミットを取得するか」を選ぶだけで、固定の正確さは損なわれない。
+
+- `…/v1/create-repo/setup.sh` を取得すると、`v1` が指すコミット（例: `v1.0.0`）の
+  `setup.sh` が得られる。その `EMBEDDED_REF` は**正確なバージョン**（`v1.0.0`）なので、
+  内部 clone も `v1.0.0` に固定される。
+- `v1` を `v1.1.0` のコミットへ動かせば、`…/v1/…` は自動的に `v1.1.0` を取得・固定する
+  （`EMBEDDED_REF` は各リリースコミットに焼き込まれているため）。
+
+### 運用ルール
+
+- **パッチ／マイナー**（`v1.0.1`, `v1.1.0` など）: 上記リリース手順の最後に
+  `git tag -f v1 vX.Y.Z && git push origin v1 --force` で `v1` を前進させる。
+- **メジャー**（`v2.0.0`）: 新しい移動タグ `v2` を作成し、利用側テンプレートの
+  README コマンド例を `/v1/` → `/v2/` に更新する（旧 `v1` は据え置きで互換維持）。
+
+```bash
+# 例: v1 系の新リリース vX.Y.Z 後に v1 を前進させる
+git tag -f v1 vX.Y.Z
+git push origin v1 --force
+```
 
 ### 検証
 
@@ -105,6 +142,10 @@ curl -fsSL https://raw.githubusercontent.com/smkwlab/thesis-management-tools/mai
 URL のブランチ部分をタグに変えるだけで、本体・内部 clone とも当該タグに固定される。
 
 ```bash
+# 最新の v1 系（移動タグ。テンプレート README はこちらを採用）
+/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/smkwlab/thesis-management-tools/v1/create-repo/setup.sh)" bash thesis
+
+# 特定パッチに完全固定（厳密な再現が必要な場合）
 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/smkwlab/thesis-management-tools/v1.0.0/create-repo/setup.sh)" bash thesis
 ```
 


### PR DESCRIPTION
## 概要

利用側テンプレート（`sotsuron-template` 等）のコマンド例を **`/v1/`（メジャー移動タグ）** に揃えるための前提として、本リポジトリ側に `v1` 移動タグの運用を整備します（GitHub Actions の `@v4` と同じ考え方）。

関連: #438（バージョン固定機構の導入）の後続作業。利用側テンプレートの README は別 PR で `/v1/` に更新します。

## 背景・狙い

- `v1` は「最新の `v1.x.x` リリース」を指す移動タグ。リリースのたびに最新へ動かす。
- これにより、パッチ／マイナーリリースのたびに各テンプレートの README を更新する必要がなくなる（README 更新が要るのはメジャー更新 `v1`→`v2` のときだけ）。
- 二段固定（`EMBEDDED_REF`）はそのまま機能: `…/v1/setup.sh` は `v1` が指すコミット（現在 v1.0.0）を取得し、その `EMBEDDED_REF="v1.0.0"` で内部 clone も正確に固定される。`v1` を前進させれば自動追従。

## 変更内容

- `docs/RELEASE.md`
  - 「メジャー移動タグ（`v1` など）」セクションを追加（運用ルール・二段固定との関係）
  - リリース手順の最後に `v1` 前進ステップ（`git tag -f v1 vX.Y.Z && git push origin v1 --force`）を追加
  - 固定版の利用例に `v1`（最新 v1 系）と `v1.0.0`（完全固定）の両方を明記
- `create-repo/README.md`
  - 固定版節に `v1`（移動タグ）の案内を追加

## 補足

- `v1` タグは既に作成済み（v1.0.0 を指す）。`…/v1/create-repo/setup.sh` の `EMBEDDED_REF="v1.0.0"` を確認済み。
- `v1` はポインタ用タグであり GitHub Release は作成しません（Release は `vX.Y.Z` のみ）。