### PR TITLE
ci: fix YAML lint failure in ai-code-review.yml (line too long)

### DIFF
--- a/.github/workflows/ai-code-review.yml
+++ b/.github/workflows/ai-code-review.yml
@@ -6,7 +6,8 @@ name: AI Code Review
 
 on:
   pull_request:
-    types: [opened, reopened, ready_for_review, synchronize]   # synchronize: re-review on each push. Drop if cost is a concern.
+    # synchronize: re-review on each push. Drop if cost is a concern.
+    types: [opened, reopened, ready_for_review, synchronize]
 
 concurrency:
   group: ai-code-review-${{ github.event.pull_request.number }}


### PR DESCRIPTION
## 背景

現在 **main の「Validate YAML files」チェックが失敗**しており、全 PR が同じ赤を引いています（例: #448）。原因は #444（`ci: re-review on push (add synchronize)`）で `.github/workflows/ai-code-review.yml` の `types:` 行末に長いコメントが付き、**line 9 が128文字（`.yamllint.yml` の上限120超）**となり line-length エラーになっていたためです。

## 修正

行末コメントを直前の独立行に移動し、120文字以内に収めました（YAML の意味は不変）:

```yaml
  pull_request:
    # synchronize: re-review on each push. Drop if cost is a concern.
    types: [opened, reopened, ready_for_review, synchronize]
```

## 検証

- ✅ 全ワークフローで120文字超の行: 0
- ✅ `yamllint -c .yamllint.yml .`: エラー0（残る document-start 等は warning で従来どおり非ブロッキング）

これで main の CI が健全化し、#448 ほか係属中の PR がアンブロックされます。

🤖 Generated with [Claude Code](https://claude.com/claude-code)