### PR TITLE
Extract duplicated INDIVIDUAL_MODE student-ID handling into common-lib

### DIFF
--- a/create-repo/common-lib.sh
+++ b/create-repo/common-lib.sh
@@ -268,6 +268,30 @@ read_student_id() {
     echo "$student_id"
 }
 
+# INDIVIDUAL_MODE を考慮した学籍番号の取得
+# - INDIVIDUAL_MODE が真のときは入力をスキップして空文字を返す
+# - それ以外は read_student_id → normalize_student_id を通した学籍番号を返す
+# ログ類は stderr に出力されるため、STUDENT_ID=$(read_student_id_if_needed "$1") の
+# ように stdout を捕捉しても汚染されない。正規化に失敗した場合は 1 を返すので、
+# set -e 環境では呼び出し側の代入がそこで停止する（従来の `|| exit 1` と同等）。
+# 使い方: STUDENT_ID=$(read_student_id_if_needed "$1" "卒業論文の例: k21rs001 ...")
+read_student_id_if_needed() {
+    local input_id="$1"
+    local examples="$2"
+
+    if [[ "$INDIVIDUAL_MODE" =~ ^(true|TRUE|1|yes|YES)$ ]]; then
+        log_debug "個人モード: 学籍番号の入力をスキップします"
+        echo ""
+        return 0
+    fi
+
+    local student_id
+    student_id=$(read_student_id "$input_id" "$examples")
+    student_id=$(normalize_student_id "$student_id") || return 1
+    log_info "学籍番号: $student_id"
+    echo "$student_id"
+}
+
 # 組織設定決定
 determine_organization() {
     local default_org="${1:-$DEFAULT_ORG}"

--- a/create-repo/common-lib.sh
+++ b/create-repo/common-lib.sh
@@ -272,9 +272,10 @@ read_student_id() {
 # - INDIVIDUAL_MODE が真のときは入力をスキップして空文字を返す
 # - それ以外は read_student_id → normalize_student_id を通した学籍番号を返す
 # ログ類は stderr に出力されるため、STUDENT_ID=$(read_student_id_if_needed "$1") の
-# ように stdout を捕捉しても汚染されない。正規化に失敗した場合は 1 を返すので、
-# set -e 環境では呼び出し側の代入がそこで停止する（従来の `|| exit 1` と同等）。
-# 使い方: STUDENT_ID=$(read_student_id_if_needed "$1" "卒業論文の例: k21rs001 ...")
+# ように stdout を捕捉しても汚染されない。正規化に失敗した場合は 1 を返す。
+# 呼び出し側は必ず `|| exit 1` を付けて使うこと（set -e 下の bare 代入でも停止するが、
+# 明示しておくことで set -e 無効時や local 代入時にも確実に停止できる）。
+# 使い方: STUDENT_ID=$(read_student_id_if_needed "$1" "卒業論文の例: k21rs001 ...") || exit 1
 read_student_id_if_needed() {
     local input_id="$1"
     local examples="$2"

--- a/create-repo/main-ise.sh
+++ b/create-repo/main-ise.sh
@@ -17,7 +17,7 @@ VISIBILITY="private"
 log_info "テンプレートリポジトリ: $TEMPLATE_REPOSITORY"
 
 # 学籍番号の取得（INDIVIDUAL_MODE のときはスキップして空文字）
-STUDENT_ID=$(read_student_id_if_needed "$1")
+STUDENT_ID=$(read_student_id_if_needed "$1") || exit 1
 
 # ISE レポート番号の決定とリポジトリ存在チェック（日時ベース）
 # この関数は ISE 固有のロジックのため、ここに残す

--- a/create-repo/main-ise.sh
+++ b/create-repo/main-ise.sh
@@ -16,16 +16,8 @@ VISIBILITY="private"
 
 log_info "テンプレートリポジトリ: $TEMPLATE_REPOSITORY"
 
-# INDIVIDUAL_MODEの場合は学籍番号をスキップ
-if [[ "$INDIVIDUAL_MODE" =~ ^(true|TRUE|1|yes|YES)$ ]]; then
-    log_debug "個人モード: 学籍番号の入力をスキップします"
-    STUDENT_ID=""
-else
-    # 学籍番号の入力と検証
-    STUDENT_ID=$(read_student_id "$1")
-    STUDENT_ID=$(normalize_student_id "$STUDENT_ID") || exit 1
-    log_info "学籍番号: $STUDENT_ID"
-fi
+# 学籍番号の取得（INDIVIDUAL_MODE のときはスキップして空文字）
+STUDENT_ID=$(read_student_id_if_needed "$1")
 
 # ISE レポート番号の決定とリポジトリ存在チェック（日時ベース）
 # この関数は ISE 固有のロジックのため、ここに残す

--- a/create-repo/main-latex.sh
+++ b/create-repo/main-latex.sh
@@ -16,15 +16,8 @@ VISIBILITY="private"
 
 log_info "テンプレートリポジトリ: $TEMPLATE_REPOSITORY"
 
-# INDIVIDUAL_MODEの場合は学籍番号をスキップ
-if [[ "$INDIVIDUAL_MODE" =~ ^(true|TRUE|1|yes|YES)$ ]]; then
-    log_debug "個人モード: 学籍番号の入力をスキップします"
-    STUDENT_ID=""
-else
-    STUDENT_ID=$(read_student_id "$1")
-    STUDENT_ID=$(normalize_student_id "$STUDENT_ID") || exit 1
-    log_info "学籍番号: $STUDENT_ID"
-fi
+# 学籍番号の取得（INDIVIDUAL_MODE のときはスキップして空文字）
+STUDENT_ID=$(read_student_id_if_needed "$1")
 
 # ドキュメント名の入力
 read_document_name() {

--- a/create-repo/main-latex.sh
+++ b/create-repo/main-latex.sh
@@ -17,7 +17,7 @@ VISIBILITY="private"
 log_info "テンプレートリポジトリ: $TEMPLATE_REPOSITORY"
 
 # 学籍番号の取得（INDIVIDUAL_MODE のときはスキップして空文字）
-STUDENT_ID=$(read_student_id_if_needed "$1")
+STUDENT_ID=$(read_student_id_if_needed "$1") || exit 1
 
 # ドキュメント名の入力
 read_document_name() {

--- a/create-repo/main-poster.sh
+++ b/create-repo/main-poster.sh
@@ -17,7 +17,7 @@ VISIBILITY="private"
 log_info "テンプレートリポジトリ: $TEMPLATE_REPOSITORY"
 
 # 学籍番号の取得（INDIVIDUAL_MODE のときはスキップして空文字）
-STUDENT_ID=$(read_student_id_if_needed "$1")
+STUDENT_ID=$(read_student_id_if_needed "$1") || exit 1
 
 # ポスター名の入力
 read_poster_name() {

--- a/create-repo/main-poster.sh
+++ b/create-repo/main-poster.sh
@@ -16,18 +16,8 @@ VISIBILITY="private"
 
 log_info "テンプレートリポジトリ: $TEMPLATE_REPOSITORY"
 
-# INDIVIDUAL_MODEの場合は学籍番号をスキップ（柔軟な値判定）
-if [[ "$INDIVIDUAL_MODE" =~ ^(true|TRUE|1|yes|YES)$ ]]; then
-    log_debug "個人モード: 学籍番号の入力をスキップします"
-    STUDENT_ID=""
-else
-    # 学籍番号の入力
-    STUDENT_ID=$(read_student_id "$1")
-
-    # 学籍番号の正規化と検証
-    STUDENT_ID=$(normalize_student_id "$STUDENT_ID") || exit 1
-    log_info "学籍番号: $STUDENT_ID"
-fi
+# 学籍番号の取得（INDIVIDUAL_MODE のときはスキップして空文字）
+STUDENT_ID=$(read_student_id_if_needed "$1")
 
 # ポスター名の入力
 read_poster_name() {

--- a/create-repo/main-thesis.sh
+++ b/create-repo/main-thesis.sh
@@ -16,16 +16,8 @@ VISIBILITY="private"
 
 log_info "テンプレートリポジトリ: $TEMPLATE_REPOSITORY"
 
-# INDIVIDUAL_MODEの場合は学籍番号をスキップ
-if [[ "$INDIVIDUAL_MODE" =~ ^(true|TRUE|1|yes|YES)$ ]]; then
-    log_debug "個人モード: 学籍番号の入力をスキップします"
-    STUDENT_ID=""
-else
-    # 学籍番号の入力と検証
-    STUDENT_ID=$(read_student_id "$1" "卒業論文の例: k21rs001, 修士論文の例: k21gjk01")
-    STUDENT_ID=$(normalize_student_id "$STUDENT_ID") || exit 1
-    log_info "学籍番号: $STUDENT_ID"
-fi
+# 学籍番号の取得（INDIVIDUAL_MODE のときはスキップして空文字）
+STUDENT_ID=$(read_student_id_if_needed "$1" "卒業論文の例: k21rs001, 修士論文の例: k21gjk01")
 
 # 論文タイプの判定
 determine_thesis_type() {

--- a/create-repo/main-thesis.sh
+++ b/create-repo/main-thesis.sh
@@ -17,7 +17,7 @@ VISIBILITY="private"
 log_info "テンプレートリポジトリ: $TEMPLATE_REPOSITORY"
 
 # 学籍番号の取得（INDIVIDUAL_MODE のときはスキップして空文字）
-STUDENT_ID=$(read_student_id_if_needed "$1" "卒業論文の例: k21rs001, 修士論文の例: k21gjk01")
+STUDENT_ID=$(read_student_id_if_needed "$1" "卒業論文の例: k21rs001, 修士論文の例: k21gjk01") || exit 1
 
 # 論文タイプの判定
 determine_thesis_type() {

--- a/create-repo/main-wr.sh
+++ b/create-repo/main-wr.sh
@@ -17,7 +17,7 @@ VISIBILITY="private"
 log_info "テンプレートリポジトリ: $TEMPLATE_REPOSITORY"
 
 # 学籍番号の取得（INDIVIDUAL_MODE のときはスキップして空文字）
-STUDENT_ID=$(read_student_id_if_needed "$1")
+STUDENT_ID=$(read_student_id_if_needed "$1") || exit 1
 
 # リポジトリ名の決定
 if [[ "$INDIVIDUAL_MODE" =~ ^(true|TRUE|1|yes|YES)$ ]]; then

--- a/create-repo/main-wr.sh
+++ b/create-repo/main-wr.sh
@@ -16,16 +16,8 @@ VISIBILITY="private"
 
 log_info "テンプレートリポジトリ: $TEMPLATE_REPOSITORY"
 
-# INDIVIDUAL_MODEの場合は学籍番号をスキップ
-if [[ "$INDIVIDUAL_MODE" =~ ^(true|TRUE|1|yes|YES)$ ]]; then
-    log_debug "個人モード: 学籍番号の入力をスキップします"
-    STUDENT_ID=""
-else
-    # 学籍番号の入力と検証
-    STUDENT_ID=$(read_student_id "$1")
-    STUDENT_ID=$(normalize_student_id "$STUDENT_ID") || exit 1
-    log_info "学籍番号: $STUDENT_ID"
-fi
+# 学籍番号の取得（INDIVIDUAL_MODE のときはスキップして空文字）
+STUDENT_ID=$(read_student_id_if_needed "$1")
 
 # リポジトリ名の決定
 if [[ "$INDIVIDUAL_MODE" =~ ^(true|TRUE|1|yes|YES)$ ]]; then


### PR DESCRIPTION
resolve #450

#445 から分離した follow-up（項目3）です。

## 変更

`create-repo/` の5本の起動スクリプト（`main-thesis` / `main-wr` / `main-ise` / `main-latex` / `main-poster`）が同一の「`INDIVIDUAL_MODE` 判定 + `read_student_id` + `normalize_student_id`」ブロックを重複保持していました。

`common-lib.sh` に **`read_student_id_if_needed(input_id, examples)`** を追加し、各スクリプトの重複ブロックを1行の呼び出しに置換しました。これで `INDIVIDUAL_MODE` 判定が1箇所に集約されます（6箇所→1箇所）。

```bash
# Before (各スクリプトに重複)
if [[ "$INDIVIDUAL_MODE" =~ ^(true|TRUE|1|yes|YES)$ ]]; then
    STUDENT_ID=""
else
    STUDENT_ID=$(read_student_id "$1")
    STUDENT_ID=$(normalize_student_id "$STUDENT_ID") || exit 1
    ...
fi

# After
STUDENT_ID=$(read_student_id_if_needed "$1")
```

## 挙動の維持
- `INDIVIDUAL_MODE` 真 → `STUDENT_ID` は空（入力スキップ）
- それ以外 → 入力・正規化した学籍番号を返す。ログは stderr 出力のため `STUDENT_ID=$(...)` 捕捉を汚染しない
- 正規化失敗時は非ゼロを返し、`set -e` 環境で呼び出し側が停止（従来の `|| exit 1` と同等）
- `main-thesis` は既存のプロンプト文（卒論/修論の例）を `examples` 引数で維持
- 2つ目のブロック（リポジトリ名決定）は文書タイプ固有のため**対象外**

## 検証
- ✅ `bash -n`: 6ファイルすべて OK
- ✅ ヘルパー機能テスト（5ケース）: 個人モード=空 / 有効ID / 大文字正規化 / k 自動付与 / 不正ID=非ゼロ いずれも PASS
- ✅ shellcheck: main との SC コード差分なし（新規警告ゼロ）
- 重複ブロック残存: 0、ヘルパー呼び出し: 5本各1回

> 注: 学生リポジトリ作成の重要パスのため、マージ前に5文書タイプ × 通常/個人モード × Docker 起動での最終確認を推奨します（ローカルでは非対話の機能テストまで実施済み）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)