### PR TITLE
Support repositories outside the smkwlab/ org in setup-branch-protection.sh

### DIFF
--- a/scripts/setup-branch-protection.sh
+++ b/scripts/setup-branch-protection.sh
@@ -55,6 +55,9 @@ check_rate_limit() {
 #   0: 管理者権限あり
 #   1: 権限なしまたはエラー
 verify_admin_permissions() {
+    local owner="$1"
+    local repo_name="$2"
+
     log "GitHub CLI認証とアカウント権限を確認中..."
     
     # 現在のユーザー名を取得（GitHub Actionsとローカル両対応）
@@ -81,8 +84,8 @@ verify_admin_permissions() {
         return 0
     fi
     
-    # ローカル環境でのみadmin権限をチェック
-    local test_repo="smkwlab/thesis-management-tools"
+    # ローカル環境でのみadmin権限をチェック（対象リポジトリそのものを確認）
+    local test_repo="$owner/$repo_name"
     local has_admin
     
     log "権限確認対象: $test_repo"
@@ -102,8 +105,8 @@ verify_admin_permissions() {
         echo
         return 1
     else
-        error "権限確認に失敗しました（テストリポジトリ: $test_repo）"
-        error "リポジトリへのアクセス権限がない可能性があります"
+        error "権限確認に失敗しました（対象リポジトリ: $test_repo）"
+        error "リポジトリが存在しないか、アクセス権限がない可能性があります"
         return 1
     fi
 }
@@ -112,16 +115,17 @@ verify_admin_permissions() {
 # GitHub API では enforce_admins は別エンドポイントで設定する必要がある
 # 参照: https://docs.github.com/en/rest/branches/branch-protection#set-admin-branch-protection
 setup_enforce_admins() {
-    local repo_name="$1"
-    local enforce="$2"  # true or false
-    local branch="${3:-main}"  # 将来の拡張用（複数ブランチ対応）
+    local owner="$1"
+    local repo_name="$2"
+    local enforce="$3"  # true or false
+    local branch="${4:-main}"  # 将来の拡張用（複数ブランチ対応）
 
     log "enforce_admins 設定: $enforce (branch: $branch)"
 
     if [ "$enforce" = "true" ]; then
         # 管理者にも保護ルールを適用
         if gh api --method POST \
-           "repos/smkwlab/$repo_name/branches/$branch/protection/enforce_admins" \
+           "repos/$owner/$repo_name/branches/$branch/protection/enforce_admins" \
            >/dev/null 2>&1; then
             success "✅ enforce_admins: true を設定しました"
             return 0
@@ -132,7 +136,7 @@ setup_enforce_admins() {
     else
         # 管理者は保護ルールを回避可能（学生リポジトリ向け）
         if gh api --method DELETE \
-           "repos/smkwlab/$repo_name/branches/$branch/protection/enforce_admins" \
+           "repos/$owner/$repo_name/branches/$branch/protection/enforce_admins" \
            >/dev/null 2>&1; then
             success "✅ enforce_admins: false を設定しました（管理者は保護ルールを回避可能）"
             return 0
@@ -192,11 +196,11 @@ update_student_lists() {
 
 # ブランチ保護設定
 setup_protection() {
-    local repo_name="$1"
-    
-    log "Setting up branch protection for: smkwlab/$repo_name"
-    log "Note: 'smkwlab/' prefix is automatically added to repository name"
-    
+    local owner="$1"
+    local repo_name="$2"
+
+    log "Setting up branch protection for: $owner/$repo_name"
+
     # APIレート制限チェック
     if ! check_rate_limit; then
         error "API レート制限のため処理を中断します"
@@ -204,17 +208,17 @@ setup_protection() {
     fi
     
     # リポジトリ存在確認
-    if ! gh repo view "smkwlab/$repo_name" >/dev/null 2>&1; then
-        error "Repository not found: smkwlab/$repo_name"
+    if ! gh repo view "$owner/$repo_name" >/dev/null 2>&1; then
+        error "Repository not found: $owner/$repo_name"
         error "Please ensure the repository exists before setting up protection"
         return 1
     fi
-    
+
     # ブランチ存在確認
     local branches_to_protect=("main")
-    
-    if ! gh api "repos/smkwlab/$repo_name/branches/main" >/dev/null 2>&1; then
-        error "Main branch not found in repository: smkwlab/$repo_name"
+
+    if ! gh api "repos/$owner/$repo_name/branches/main" >/dev/null 2>&1; then
+        error "Main branch not found in repository: $owner/$repo_name"
         return 1
     fi
 
@@ -251,7 +255,7 @@ setup_protection() {
         log "ブランチ '$branch' の保護設定を確認中..."
         
         # 既存の保護設定確認（冪等性保証）
-        if gh api "repos/smkwlab/$repo_name/branches/$branch/protection" >/dev/null 2>&1; then
+        if gh api "repos/$owner/$repo_name/branches/$branch/protection" >/dev/null 2>&1; then
             log "ブランチ '$branch' は既に保護設定済みです"
             success_count=$((success_count + 1))
             continue
@@ -260,7 +264,7 @@ setup_protection() {
         log "ブランチ '$branch' に保護設定を適用中..."
         if [ -n "${GITHUB_ACTIONS:-}" ]; then
             # GitHub Actions環境では詳細なエラー情報を出力
-            if echo "$protection_config" | gh api "repos/smkwlab/$repo_name/branches/$branch/protection" \
+            if echo "$protection_config" | gh api "repos/$owner/$repo_name/branches/$branch/protection" \
                 --method PUT \
                 --input - 2>&1; then
                 success "✅ ブランチ '$branch' の保護設定が完了しました"
@@ -272,7 +276,7 @@ setup_protection() {
             fi
         else
             # ローカル環境では従来通り
-            if echo "$protection_config" | gh api "repos/smkwlab/$repo_name/branches/$branch/protection" \
+            if echo "$protection_config" | gh api "repos/$owner/$repo_name/branches/$branch/protection" \
                 --method PUT \
                 --input - >/dev/null 2>&1; then
                 success "✅ ブランチ '$branch' の保護設定が完了しました"
@@ -285,7 +289,7 @@ setup_protection() {
     
     if [ "$success_count" -eq "$total_branches" ]; then
         success "✅ すべてのブランチ保護設定が完了しました ($success_count/$total_branches)"
-        success "   Repository: https://github.com/smkwlab/$repo_name"
+        success "   Repository: https://github.com/$owner/$repo_name"
         success "   Protected branches: ${branches_to_protect[*]}"
         success "   Protection rules:"
         success "     - Requires 1 approving review before merge"
@@ -294,7 +298,7 @@ setup_protection() {
 
         # enforce_admins を false に設定（学生リポジトリでは管理者が直接操作できるようにする）
         # 注: テンプレートリポジトリでは true を設定すべきだが、このスクリプトは学生リポジトリ用
-        if ! setup_enforce_admins "$repo_name" "false"; then
+        if ! setup_enforce_admins "$owner" "$repo_name" "false"; then
             error "❌ enforce_admins 設定に失敗しました"
             return 1
         fi
@@ -316,15 +320,25 @@ show_help() {
 Individual Branch Protection Setup Script
 
 Usage: $0 <repository_name>
+       $0 <owner>/<repository_name>
 
 Arguments:
-  repository_name  Repository name (without smkwlab/ prefix)
+  repository_name        Repository name only. The owner defaults to
+                         \$REPO_OWNER (default: smkwlab).
+  owner/repository_name  Fully-qualified target. Use this form to set up
+                         protection for repositories outside the smkwlab
+                         organization (e.g. personal accounts).
+
+Environment:
+  REPO_OWNER   Default owner used when the argument has no '<owner>/' prefix
+               (default: smkwlab)
 
 Examples:
-  $0 k21rs001-sotsuron          # Setup protection for thesis repository (→ smkwlab/k21rs001-sotsuron)
-  $0 k21gjk01-thesis            # Setup protection for graduate thesis (→ smkwlab/k21gjk01-thesis)
-  $0 k02jk059-ise-report1       # Setup protection for ISE report repository (→ smkwlab/k02jk059-ise-report1)
-  $0 k21rs001-wr                # Setup protection for weekly report repository (→ smkwlab/k21rs001-wr)
+  $0 k21rs001-sotsuron              # → smkwlab/k21rs001-sotsuron (default owner)
+  $0 k21gjk01-thesis                # → smkwlab/k21gjk01-thesis
+  $0 k02jk059-ise-report1           # → smkwlab/k02jk059-ise-report1
+  $0 myorg/k21rs001-sotsuron        # → myorg/k21rs001-sotsuron (explicit owner)
+  REPO_OWNER=myuser $0 my-paper     # → myuser/my-paper (owner via env var)
 
 Protection Rules Applied:
   - Requires 1 approving review before merge
@@ -341,28 +355,47 @@ EOF
 
 # メイン処理
 main() {
-    local repo_name="$1"
-    
-    if [ -z "$repo_name" ]; then
+    local input="$1"
+
+    if [ -z "$input" ]; then
         error "Repository name is required"
         echo
         show_help
         exit 1
     fi
-    
+
+    # owner/repo の解決
+    #   - "<owner>/<repo>" 形式が渡された場合は owner を抽出する
+    #   - リポジトリ名のみの場合は REPO_OWNER（既定: smkwlab）を owner とする
+    local owner repo_name
+    if [[ "$input" == */* ]]; then
+        owner="${input%%/*}"
+        repo_name="${input#*/}"
+    else
+        owner="${REPO_OWNER:-smkwlab}"
+        repo_name="$input"
+    fi
+
+    # owner / repo_name の妥当性チェック（空・多重スラッシュを拒否）
+    if [ -z "$owner" ] || [ -z "$repo_name" ] || [[ "$repo_name" == */* ]]; then
+        error "Invalid repository specification: $input"
+        error "Expected '<repository_name>' or '<owner>/<repository_name>'"
+        exit 1
+    fi
+
     # GitHub CLI認証確認（GitHub Actionsとローカル両対応）
     if ! gh auth status >/dev/null 2>&1; then
         error "GitHub CLI is not authenticated or current account is invalid"
         error "Please run 'gh auth login' first"
         exit 1
     fi
-    
+
     # アカウント権限チェック
-    if ! verify_admin_permissions; then
+    if ! verify_admin_permissions "$owner" "$repo_name"; then
         exit 1
     fi
-    
-    setup_protection "$repo_name"
+
+    setup_protection "$owner" "$repo_name"
 }
 
 # コマンドライン処理

--- a/scripts/setup-branch-protection.sh
+++ b/scripts/setup-branch-protection.sh
@@ -430,7 +430,8 @@ main() {
     #   - repo_name（リポジトリ名）: 英数字と '.' '_' '-'
     # これにより空文字・多重スラッシュ（例: owner//repo, a/b/c）・先頭/末尾スラッシュ・
     # 先頭ハイフンの owner（例: -badowner）・空白などの不正文字をまとめて弾く。
-    # 注: 末尾ハイフン・連続ハイフンの禁止までは検証しない。そうした値はここを通過
+    # 注: 1 文字の owner（例: a）は許可する。末尾/連続ハイフンの owner や、
+    # '.'/'..' のような病的な repo_name の禁止までは検証せず、それらはここを通過
     # しても最終的に GitHub API 側でエラーとなる。
     if [[ ! "$owner" =~ ^[A-Za-z0-9][A-Za-z0-9-]*$ ]] || [[ ! "$repo_name" =~ ^[A-Za-z0-9._-]+$ ]]; then
         error "Invalid repository specification: $input"

--- a/scripts/setup-branch-protection.sh
+++ b/scripts/setup-branch-protection.sh
@@ -15,8 +15,8 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 #   DEFAULT_OWNER  : 引数に '<owner>/' プレフィックスが無い場合に補完する既定 owner
 #   REGISTRY_OWNER : 学生レジストリ（thesis-student-registry）の管理対象 owner。
 #                    対象 owner がこの値と一致する場合のみレジストリを更新する。
-DEFAULT_OWNER="${REPO_OWNER:-smkwlab}"
-REGISTRY_OWNER="${REGISTRY_OWNER:-smkwlab}"
+readonly DEFAULT_OWNER="${REPO_OWNER:-smkwlab}"
+readonly REGISTRY_OWNER="${REGISTRY_OWNER:-smkwlab}"
 
 # カラー定義
 RED='\033[0;31m'
@@ -239,8 +239,8 @@ setup_protection() {
     # ローカル実行時は verify_admin_permissions の API 呼び出しと一部重複するが、
     # Actions 経路での存在保証のため意図的に残している。
     if ! gh repo view "$owner/$repo_name" >/dev/null 2>&1; then
-        error "Repository not found: $owner/$repo_name"
-        error "Please ensure the repository exists before setting up protection"
+        error "Repository not found or no read access: $owner/$repo_name"
+        error "Please ensure the repository exists and is accessible before setting up protection"
         return 1
     fi
 

--- a/scripts/setup-branch-protection.sh
+++ b/scripts/setup-branch-protection.sh
@@ -11,6 +11,13 @@ set -e
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
+# デフォルト設定（環境変数で上書き可能）
+#   DEFAULT_OWNER  : 引数に '<owner>/' プレフィックスが無い場合に補完する既定 owner
+#   REGISTRY_OWNER : 学生レジストリ（thesis-student-registry）の管理対象 owner。
+#                    対象 owner がこの値と一致する場合のみレジストリを更新する。
+DEFAULT_OWNER="${REPO_OWNER:-smkwlab}"
+REGISTRY_OWNER="${REGISTRY_OWNER:-smkwlab}"
+
 # カラー定義
 RED='\033[0;31m'
 GREEN='\033[0;32m'
@@ -51,8 +58,12 @@ check_rate_limit() {
 }
 
 # アカウント権限チェック
+# 注: GitHub Actions 環境（GITHUB_ACTIONS が設定済み）では、GITHUB_TOKEN に
+#     十分な権限が保証されているため admin 権限チェックを早期 return でスキップする。
+#     そのためリポジトリ存在確認はローカル経路でのみ本関数が行い、Actions 経路では
+#     setup_protection 側の存在確認が担う（経路によりエラーメッセージが異なりうる）。
 # 返り値:
-#   0: 管理者権限あり
+#   0: 管理者権限あり（または Actions 環境でチェックスキップ）
 #   1: 権限なしまたはエラー
 verify_admin_permissions() {
     local owner="$1"
@@ -323,13 +334,12 @@ setup_protection() {
         fi
 
         # 学生リストの更新（pending → completed）
-        # 学生レジストリ（thesis-student-registry）は smkwlab の学生リポジトリのみを
-        # 管理対象とするため、owner がレジストリ owner と異なる場合はスキップする。
-        local registry_owner="${REGISTRY_OWNER:-smkwlab}"
-        if [ "$owner" = "$registry_owner" ]; then
+        # 学生レジストリ（thesis-student-registry）は REGISTRY_OWNER 配下の学生
+        # リポジトリのみを管理対象とするため、owner が一致しない場合はスキップする。
+        if [ "$owner" = "$REGISTRY_OWNER" ]; then
             update_student_lists "$repo_name"
         else
-            log "owner '$owner' は学生レジストリ（$registry_owner）の管理対象外のため、registry 更新をスキップします"
+            log "owner '$owner' は学生レジストリ（$REGISTRY_OWNER）の管理対象外のため、registry 更新をスキップします"
         fi
 
         return 0
@@ -406,7 +416,7 @@ main() {
         owner="${input%%/*}"
         repo_name="${input#*/}"
     else
-        owner="${REPO_OWNER:-smkwlab}"
+        owner="$DEFAULT_OWNER"
         repo_name="$input"
     fi
 

--- a/scripts/setup-branch-protection.sh
+++ b/scripts/setup-branch-protection.sh
@@ -223,6 +223,10 @@ setup_protection() {
     fi
     
     # リポジトリ存在確認
+    # 注: verify_admin_permissions は GitHub Actions 環境では権限チェックを
+    # スキップする（早期 return する）ため、存在確認はこのパスで必ず行う。
+    # ローカル実行時は verify_admin_permissions の API 呼び出しと一部重複するが、
+    # Actions 経路での存在保証のため意図的に残している。
     if ! gh repo view "$owner/$repo_name" >/dev/null 2>&1; then
         error "Repository not found: $owner/$repo_name"
         error "Please ensure the repository exists before setting up protection"
@@ -352,8 +356,11 @@ Arguments:
                          organization (e.g. personal accounts).
 
 Environment:
-  REPO_OWNER   Default owner used when the argument has no '<owner>/' prefix
-               (default: smkwlab)
+  REPO_OWNER     Default owner used when the argument has no '<owner>/' prefix
+                 (default: smkwlab)
+  REGISTRY_OWNER Owner whose repositories are tracked in the student registry.
+                 The registry (thesis-student-registry) is only updated when the
+                 target owner matches this value (default: smkwlab)
 
 Examples:
   $0 k21rs001-sotsuron              # → smkwlab/k21rs001-sotsuron (default owner)
@@ -389,6 +396,11 @@ main() {
     # owner/repo の解決
     #   - "<owner>/<repo>" 形式が渡された場合は owner を抽出する
     #   - リポジトリ名のみの場合は REPO_OWNER（既定: smkwlab）を owner とする
+    # "<owner>/<repo>" を分割する。
+    #   - owner     = 最初の '/' より前   : ${input%%/*}
+    #   - repo_name = 最初の '/' より後ろ : ${input#*/}
+    # 多重スラッシュ（例: a/b/c）の場合は repo_name に '/' が残るため
+    # （owner=a, repo_name=b/c）、後続の正規表現バリデーションで弾かれる。
     local owner repo_name
     if [[ "$input" == */* ]]; then
         owner="${input%%/*}"
@@ -404,6 +416,8 @@ main() {
     #   - repo_name（リポジトリ名）: 英数字と '.' '_' '-'
     # これにより空文字・多重スラッシュ（例: owner//repo, a/b/c）・先頭/末尾スラッシュ・
     # 空白などの不正文字をまとめて弾く。
+    # 注: GitHub の完全な命名規則（先頭/末尾ハイフン禁止・連続ハイフン禁止等）までは
+    # 検証しない。そうした値は最終的に GitHub API 側でエラーとなる。
     if [[ ! "$owner" =~ ^[A-Za-z0-9-]+$ ]] || [[ ! "$repo_name" =~ ^[A-Za-z0-9._-]+$ ]]; then
         error "Invalid repository specification: $input"
         error "Expected '<repository_name>' or '<owner>/<repository_name>'"

--- a/scripts/setup-branch-protection.sh
+++ b/scripts/setup-branch-protection.sh
@@ -303,6 +303,8 @@ setup_protection() {
                 local api_exit_code=$?
                 error "❌ ブランチ '$branch' の保護設定に失敗しました (exit code: $api_exit_code)"
                 error "GitHub Actions環境でのAPI エラーです。詳細は上記のエラーメッセージを確認してください。"
+                error "ヒント: Actions では権限チェックをスキップするため、GITHUB_TOKEN に"
+                error "      'administration: write'（ブランチ保護の管理権限）が付与されているか確認してください。"
             fi
         else
             # ローカル環境では従来通り
@@ -421,13 +423,13 @@ main() {
     fi
 
     # owner / repo_name の妥当性チェック
-    # GitHub の命名規則に合わせ、owner と repo_name で許可文字を分ける。
-    #   - owner（ユーザー/組織名）: 英数字とハイフンのみ（'.' '_' は不可）
+    # ここでは「許可文字の集合」だけを GitHub の命名規則に合わせて検証する。
+    #   - owner（ユーザー/組織名）: 英数字とハイフン（'.' '_' は不可）
     #   - repo_name（リポジトリ名）: 英数字と '.' '_' '-'
     # これにより空文字・多重スラッシュ（例: owner//repo, a/b/c）・先頭/末尾スラッシュ・
     # 空白などの不正文字をまとめて弾く。
-    # 注: GitHub の完全な命名規則（先頭/末尾ハイフン禁止・連続ハイフン禁止等）までは
-    # 検証しない。そうした値は最終的に GitHub API 側でエラーとなる。
+    # 注: 文字集合のみを検査し、ハイフンの位置規則（先頭/末尾/連続の禁止）までは
+    # 検証しない。そうした値はここを通過しても最終的に GitHub API 側でエラーとなる。
     if [[ ! "$owner" =~ ^[A-Za-z0-9-]+$ ]] || [[ ! "$repo_name" =~ ^[A-Za-z0-9._-]+$ ]]; then
         error "Invalid repository specification: $input"
         error "Expected '<repository_name>' or '<owner>/<repository_name>'"

--- a/scripts/setup-branch-protection.sh
+++ b/scripts/setup-branch-protection.sh
@@ -105,8 +105,15 @@ verify_admin_permissions() {
         echo
         return 1
     else
-        error "権限確認に失敗しました（対象リポジトリ: $test_repo）"
-        error "リポジトリが存在しないか、アクセス権限がない可能性があります"
+        # has_admin が true/false 以外（空）の場合は、リポジトリ未作成か
+        # アクセス不可のどちらか。原因を切り分けて具体的なメッセージを出す。
+        if ! gh repo view "$test_repo" >/dev/null 2>&1; then
+            error "リポジトリが見つかりません: $test_repo"
+            error "リポジトリを作成してから再実行してください"
+        else
+            error "権限確認に失敗しました（対象リポジトリ: $test_repo）"
+            error "このアカウントには $test_repo への管理者権限がない可能性があります"
+        fi
         return 1
     fi
 }
@@ -181,6 +188,10 @@ update_student_lists() {
 
     if [ -n "$registry_manager_path" ]; then
         log "registry-manager を使用して保護状態を更新: $registry_manager_path"
+        # registry-manager はレジストリ owner（smkwlab）配下の owner なしリポジトリ名で
+        # 学生リポジトリを引くため、owner は付けず "$repo_name" のみを渡すのが正しい。
+        # （owner != registry_owner の場合は上のガードで既に return 済み）
+        #
         # set -e 下でも registry 更新失敗でスクリプト全体が終了しないよう、
         # コマンド置換を if 条件で評価して終了コードを安全に判定する
         local output
@@ -387,10 +398,14 @@ main() {
         repo_name="$input"
     fi
 
-    # owner / repo_name の妥当性チェック（空・多重スラッシュを拒否）
-    if [ -z "$owner" ] || [ -z "$repo_name" ] || [[ "$repo_name" == */* ]]; then
+    # owner / repo_name の妥当性チェック
+    # GitHub のユーザー/組織名・リポジトリ名として有効な文字（英数字・ '.' '_' '-'）のみ許可する。
+    # これにより空文字・多重スラッシュ（例: owner//repo）・先頭/末尾スラッシュ・
+    # 空白などの不正文字をまとめて弾く。
+    if [[ ! "$owner" =~ ^[A-Za-z0-9._-]+$ ]] || [[ ! "$repo_name" =~ ^[A-Za-z0-9._-]+$ ]]; then
         error "Invalid repository specification: $input"
         error "Expected '<repository_name>' or '<owner>/<repository_name>'"
+        error "(owner and repository name may contain only letters, digits, '.', '_' and '-')"
         exit 1
     fi
 

--- a/scripts/setup-branch-protection.sh
+++ b/scripts/setup-branch-protection.sh
@@ -150,8 +150,17 @@ setup_enforce_admins() {
 
 # 学生リストの更新（pending → completed）
 update_student_lists() {
-    local repo_name="$1"
+    local owner="$1"
+    local repo_name="$2"
     # データは thesis-student-registry で管理されるため、ローカルファイル操作は不要
+
+    # 学生レジストリ（thesis-student-registry）は smkwlab の学生リポジトリのみを管理対象とする。
+    # smkwlab 以外の owner（個人アカウント等）はレジストリ対象外なので更新をスキップする。
+    local registry_owner="${REGISTRY_OWNER:-smkwlab}"
+    if [ "$owner" != "$registry_owner" ]; then
+        log "owner '$owner' は学生レジストリ（$registry_owner）の管理対象外のため、registry 更新をスキップします"
+        return 0
+    fi
 
     log "ブランチ保護設定の記録中..."
 
@@ -172,8 +181,10 @@ update_student_lists() {
 
     if [ -n "$registry_manager_path" ]; then
         log "registry-manager を使用して保護状態を更新: $registry_manager_path"
-        output=$("$registry_manager_path" protect "$repo_name" 2>&1)
-        if [ $? -eq 0 ]; then
+        # set -e 下でも registry 更新失敗でスクリプト全体が終了しないよう、
+        # コマンド置換を if 条件で評価して終了コードを安全に判定する
+        local output
+        if output=$("$registry_manager_path" protect "$repo_name" 2>&1); then
             success "✅ registry-manager で保護状態を更新しました"
             success "✅ ブランチ保護設定の記録が完了しました"
         else
@@ -304,7 +315,7 @@ setup_protection() {
         fi
 
         # 学生リストの更新（pending → completed）
-        update_student_lists "$repo_name"
+        update_student_lists "$owner" "$repo_name"
 
         return 0
     else

--- a/scripts/setup-branch-protection.sh
+++ b/scripts/setup-branch-protection.sh
@@ -87,11 +87,19 @@ verify_admin_permissions() {
     # ローカル環境でのみadmin権限をチェック（対象リポジトリそのものを確認）
     local test_repo="$owner/$repo_name"
     local has_admin
-    
+
     log "権限確認対象: $test_repo"
-    
-    has_admin=$(gh api "repos/$test_repo" --jq '.permissions.admin' 2>/dev/null)
-    
+
+    # 単一の API 呼び出しで存在確認と権限取得を兼ねる。
+    #   - 呼び出し自体が失敗 → リポジトリ未作成 or 参照権限なし
+    #   - 成功して .permissions.admin が true/false → 権限の有無
+    #   - 成功したが値が空 → トークンのスコープ不足等で権限情報を取得できず
+    if ! has_admin=$(gh api "repos/$test_repo" --jq '.permissions.admin' 2>/dev/null); then
+        error "リポジトリが見つからないか、参照権限がありません: $test_repo"
+        error "リポジトリ名・owner・アカウントのアクセス権限を確認してください"
+        return 1
+    fi
+
     if [ "$has_admin" = "true" ]; then
         success "✅ 管理者権限を確認しました"
         return 0
@@ -105,15 +113,8 @@ verify_admin_permissions() {
         echo
         return 1
     else
-        # has_admin が true/false 以外（空）の場合は、リポジトリ未作成か
-        # アクセス不可のどちらか。原因を切り分けて具体的なメッセージを出す。
-        if ! gh repo view "$test_repo" >/dev/null 2>&1; then
-            error "リポジトリが見つかりません: $test_repo"
-            error "リポジトリを作成してから再実行してください"
-        else
-            error "権限確認に失敗しました（対象リポジトリ: $test_repo）"
-            error "このアカウントには $test_repo への管理者権限がない可能性があります"
-        fi
+        error "権限情報の取得に失敗しました（対象リポジトリ: $test_repo）"
+        error "トークンのスコープが不足している可能性があります"
         return 1
     fi
 }
@@ -157,17 +158,9 @@ setup_enforce_admins() {
 
 # 学生リストの更新（pending → completed）
 update_student_lists() {
-    local owner="$1"
-    local repo_name="$2"
+    local repo_name="$1"
     # データは thesis-student-registry で管理されるため、ローカルファイル操作は不要
-
-    # 学生レジストリ（thesis-student-registry）は smkwlab の学生リポジトリのみを管理対象とする。
-    # smkwlab 以外の owner（個人アカウント等）はレジストリ対象外なので更新をスキップする。
-    local registry_owner="${REGISTRY_OWNER:-smkwlab}"
-    if [ "$owner" != "$registry_owner" ]; then
-        log "owner '$owner' は学生レジストリ（$registry_owner）の管理対象外のため、registry 更新をスキップします"
-        return 0
-    fi
+    # 注: レジストリ対象 owner かどうかの判定は呼び出し元で行う（本関数はレジストリ更新に専念）。
 
     log "ブランチ保護設定の記録中..."
 
@@ -326,7 +319,14 @@ setup_protection() {
         fi
 
         # 学生リストの更新（pending → completed）
-        update_student_lists "$owner" "$repo_name"
+        # 学生レジストリ（thesis-student-registry）は smkwlab の学生リポジトリのみを
+        # 管理対象とするため、owner がレジストリ owner と異なる場合はスキップする。
+        local registry_owner="${REGISTRY_OWNER:-smkwlab}"
+        if [ "$owner" = "$registry_owner" ]; then
+            update_student_lists "$repo_name"
+        else
+            log "owner '$owner' は学生レジストリ（$registry_owner）の管理対象外のため、registry 更新をスキップします"
+        fi
 
         return 0
     else
@@ -399,13 +399,16 @@ main() {
     fi
 
     # owner / repo_name の妥当性チェック
-    # GitHub のユーザー/組織名・リポジトリ名として有効な文字（英数字・ '.' '_' '-'）のみ許可する。
-    # これにより空文字・多重スラッシュ（例: owner//repo）・先頭/末尾スラッシュ・
+    # GitHub の命名規則に合わせ、owner と repo_name で許可文字を分ける。
+    #   - owner（ユーザー/組織名）: 英数字とハイフンのみ（'.' '_' は不可）
+    #   - repo_name（リポジトリ名）: 英数字と '.' '_' '-'
+    # これにより空文字・多重スラッシュ（例: owner//repo, a/b/c）・先頭/末尾スラッシュ・
     # 空白などの不正文字をまとめて弾く。
-    if [[ ! "$owner" =~ ^[A-Za-z0-9._-]+$ ]] || [[ ! "$repo_name" =~ ^[A-Za-z0-9._-]+$ ]]; then
+    if [[ ! "$owner" =~ ^[A-Za-z0-9-]+$ ]] || [[ ! "$repo_name" =~ ^[A-Za-z0-9._-]+$ ]]; then
         error "Invalid repository specification: $input"
         error "Expected '<repository_name>' or '<owner>/<repository_name>'"
-        error "(owner and repository name may contain only letters, digits, '.', '_' and '-')"
+        error "  e.g. 'k21rs001-sotsuron' or 'smkwlab/k21rs001-sotsuron'"
+        error "  (multi-slash like 'a/b/c', empty parts, or spaces are not allowed)"
         exit 1
     fi
 

--- a/scripts/setup-branch-protection.sh
+++ b/scripts/setup-branch-protection.sh
@@ -234,14 +234,16 @@ setup_protection() {
     fi
     
     # リポジトリ存在確認
-    # 注: verify_admin_permissions は GitHub Actions 環境では権限チェックを
-    # スキップする（早期 return する）ため、存在確認はこのパスで必ず行う。
-    # ローカル実行時は verify_admin_permissions の API 呼び出しと一部重複するが、
-    # Actions 経路での存在保証のため意図的に残している。
-    if ! gh repo view "$owner/$repo_name" >/dev/null 2>&1; then
-        error "Repository not found or no read access: $owner/$repo_name"
-        error "Please ensure the repository exists and is accessible before setting up protection"
-        return 1
+    # ローカル経路では verify_admin_permissions が gh api で存在＋権限を確認済み
+    # のため、ここでの再確認は行わない（同一リポジトリへの二重 API 呼び出しを回避）。
+    # 一方 GitHub Actions 経路では verify_admin_permissions が権限チェックを
+    # スキップ（早期 return）するため、存在確認はこのパスで実施する。
+    if [ -n "${GITHUB_ACTIONS:-}" ]; then
+        if ! gh repo view "$owner/$repo_name" >/dev/null 2>&1; then
+            error "Repository not found or no read access: $owner/$repo_name"
+            error "Please ensure the repository exists and is accessible before setting up protection"
+            return 1
+        fi
     fi
 
     # ブランチ存在確認
@@ -423,14 +425,14 @@ main() {
     fi
 
     # owner / repo_name の妥当性チェック
-    # ここでは「許可文字の集合」だけを GitHub の命名規則に合わせて検証する。
-    #   - owner（ユーザー/組織名）: 英数字とハイフン（'.' '_' は不可）
+    # GitHub の命名規則に合わせて検証する。
+    #   - owner（ユーザー/組織名）: 英数字とハイフン。先頭は英数字（先頭ハイフン不可）。
     #   - repo_name（リポジトリ名）: 英数字と '.' '_' '-'
     # これにより空文字・多重スラッシュ（例: owner//repo, a/b/c）・先頭/末尾スラッシュ・
-    # 空白などの不正文字をまとめて弾く。
-    # 注: 文字集合のみを検査し、ハイフンの位置規則（先頭/末尾/連続の禁止）までは
-    # 検証しない。そうした値はここを通過しても最終的に GitHub API 側でエラーとなる。
-    if [[ ! "$owner" =~ ^[A-Za-z0-9-]+$ ]] || [[ ! "$repo_name" =~ ^[A-Za-z0-9._-]+$ ]]; then
+    # 先頭ハイフンの owner（例: -badowner）・空白などの不正文字をまとめて弾く。
+    # 注: 末尾ハイフン・連続ハイフンの禁止までは検証しない。そうした値はここを通過
+    # しても最終的に GitHub API 側でエラーとなる。
+    if [[ ! "$owner" =~ ^[A-Za-z0-9][A-Za-z0-9-]*$ ]] || [[ ! "$repo_name" =~ ^[A-Za-z0-9._-]+$ ]]; then
         error "Invalid repository specification: $input"
         error "Expected '<repository_name>' or '<owner>/<repository_name>'"
         error "  e.g. 'k21rs001-sotsuron' or 'smkwlab/k21rs001-sotsuron'"


### PR DESCRIPTION
## 概要

`scripts/setup-branch-protection.sh` の owner ハードコード（`smkwlab` 固定）を解消し、`smkwlab/` 以外のリポジトリ（個人アカウント・他 org）にもブランチ保護を設定できるようにしました。

resolve #464

## 変更内容

- 引数で `<owner>/<repository_name>` 形式を受け付けるよう変更。`/` を含まない場合は従来どおり `$REPO_OWNER`（既定 `smkwlab`）を owner として補完し、**後方互換を維持**。
- 解決した owner を `verify_admin_permissions` / `setup_protection` / `setup_enforce_admins` に引き回し、ハードコードされていた `smkwlab/` の API パスと成功ログ URL をすべて `$owner/...` に置換。
- `verify_admin_permissions` の権限チェック対象を、固定の `smkwlab/thesis-management-tools` プロキシから**対象リポジトリ自身**に変更（他 owner でも正しく権限判定できるようにするため）。
- 異常系（多重スラッシュ・空 owner / repo）を弾くバリデーションを追加。
- `--help` の Usage / Arguments / Examples を更新し、`REPO_OWNER` 環境変数を明記。

## 後方互換性

呼び出し側 `process-pending-issues.sh`（L1245, L1304, L1502, L1555）は owner なしの `$CURRENT_REPO_NAME` を渡しており、これは `smkwlab/<repo>` に解決されるため**既存フローに影響なし**。

## 検証

- `bash -n` 構文チェック: OK
- `--help` 出力: 新仕様を反映していることを確認
- owner 解決ロジックの単体確認:
  - `k21rs001-sotsuron` → `smkwlab/k21rs001-sotsuron`（後方互換）
  - `myorg/k21rs001-sotsuron` → `myorg/k21rs001-sotsuron`
  - `REPO_OWNER=myuser my-paper` → `myuser/my-paper`
  - `a/b/c` / `/repo` / `owner/` → INVALID（適切に拒否）

## 補足

- 実際の GitHub API 呼び出し（保護設定の PUT 等）は admin 権限を持つ対象リポジトリが必要なため、本 PR ではドライ検証のみ実施しています。
- `smkwlab` 以外の owner では、実行アカウントのトークンに当該リポジトリの admin 権限が必要です（README/help の Requirements に準拠）。