### PR TITLE
registry-manager のリポジトリ分離に伴うツールパス更新

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -90,11 +90,13 @@ scripts/
 
 **IMPORTANT**: Student data management has been consolidated into `thesis-student-registry`:
 
-- **Student registry**: `thesis-student-registry/data/repositories.json`
-- **Management tool**: `registry-manager` (Elixir escript)
-- **Monitoring tool**: `thesis-monitor` (Elixir escript)
+- **Student registry (data)**: `thesis-student-registry/data/repositories.json` (private repo)
+- **Management tool**: [smkwlab/registry-manager](https://github.com/smkwlab/registry-manager) (Elixir escript, separate repo)
+- **Monitoring tool**: [smkwlab/thesis-monitor](https://github.com/smkwlab/thesis-monitor) (Elixir escript, separate repo)
 
 All operations now use GitHub API for safe, atomic data management instead of local files.
+The tools read the data repository location from `~/.config/registry-manager/config.json`
+(`data_repo`) or a thesis-monitor YAML config (`data_dir`).
 
 ## Document Type Configuration
 
@@ -149,18 +151,21 @@ docker build -f create-repo/Dockerfile -t test-creator .
 
 ### Data Management (Registry Manager Integration)
 ```bash
-# View repository registry status
-cd thesis-student-registry
-./thesis_monitor/thesis-monitor status
+# Build the tools (each in its own checkout)
+(cd registry-manager && mix escript.build)
+(cd thesis-monitor && mix escript.build)
+
+# View repository status
+./thesis-monitor/thesis-monitor status
 
 # Add new repository to registry
-./registry_manager/registry-manager add k21rs001-sotsuron k21rs001 sotsuron active thesis
+./registry-manager/registry-manager add k21rs001-sotsuron
 
 # Mark branch protection complete
-./registry_manager/registry-manager protect k21rs001-sotsuron
+./registry-manager/registry-manager protect k21rs001-sotsuron
 
 # Update repository status
-./registry_manager/registry-manager update k21rs001-sotsuron status completed
+./registry-manager/registry-manager update k21rs001-sotsuron status completed
 ```
 
 ### Debug Authentication Issues

--- a/scripts/setup-branch-protection.sh
+++ b/scripts/setup-branch-protection.sh
@@ -182,10 +182,12 @@ update_student_lists() {
     # 1. コマンドとして利用可能かチェック
     if command -v registry-manager >/dev/null 2>&1; then
         registry_manager_path="registry-manager"
-    # 2. 相対パスで探す（thesis-management-tools から registry-manager checkout へ）
+    # 2. スクリプト位置基準で探す（リポジトリルートの親にある sibling checkout）
     elif [ -x "$SCRIPT_DIR/../../registry-manager/registry-manager" ]; then
         registry_manager_path="$SCRIPT_DIR/../../registry-manager/registry-manager"
-    # 3. 絶対パスで探す（GitHub Actions 環境）
+    # 3. カレントディレクトリ基準のフォールバック
+    #    （実行時 CWD がリポジトリルートで、その親に checkout がある場合のみ有効。
+    #      CWD に依存するため 2. が失敗した場合の補助として残している）
     elif [ -x "$PWD/../registry-manager/registry-manager" ]; then
         registry_manager_path="$PWD/../registry-manager/registry-manager"
     # 4. 旧配置（thesis-student-registry 内、移行期間中のフォールバック）

--- a/scripts/setup-branch-protection.sh
+++ b/scripts/setup-branch-protection.sh
@@ -176,16 +176,21 @@ update_student_lists() {
     log "ブランチ保護設定の記録中..."
 
     # registry-manager で保護状態を更新
-    # thesis-student-registry/registry_manager/registry-manager を探す
+    # ツールは smkwlab/registry-manager リポジトリ（sibling checkout）に分離された
     local registry_manager_path=""
 
     # 1. コマンドとして利用可能かチェック
     if command -v registry-manager >/dev/null 2>&1; then
         registry_manager_path="registry-manager"
-    # 2. 相対パスで探す（thesis-management-tools から thesis-student-registry へ）
+    # 2. 相対パスで探す（thesis-management-tools から registry-manager checkout へ）
+    elif [ -x "$SCRIPT_DIR/../../registry-manager/registry-manager" ]; then
+        registry_manager_path="$SCRIPT_DIR/../../registry-manager/registry-manager"
+    # 3. 絶対パスで探す（GitHub Actions 環境）
+    elif [ -x "$PWD/../registry-manager/registry-manager" ]; then
+        registry_manager_path="$PWD/../registry-manager/registry-manager"
+    # 4. 旧配置（thesis-student-registry 内、移行期間中のフォールバック）
     elif [ -x "$SCRIPT_DIR/../../thesis-student-registry/registry_manager/registry-manager" ]; then
         registry_manager_path="$SCRIPT_DIR/../../thesis-student-registry/registry_manager/registry-manager"
-    # 3. 絶対パスで探す（GitHub Actions 環境）
     elif [ -x "$PWD/../thesis-student-registry/registry_manager/registry-manager" ]; then
         registry_manager_path="$PWD/../thesis-student-registry/registry_manager/registry-manager"
     fi


### PR DESCRIPTION
## 概要

smkwlab/thesis-student-registry#128 の Phase 5。registry-manager / thesis-monitor がそれぞれ独立リポジトリ（smkwlab/registry-manager, smkwlab/thesis-monitor）に分離されたことに伴う追従。

## 変更内容

- **scripts/setup-branch-protection.sh**: registry-manager バイナリの探索パスを更新
  1. PATH 上の `registry-manager`
  2. sibling checkout `../registry-manager/registry-manager`（新配置）
  3. 旧配置 `../thesis-student-registry/registry_manager/registry-manager`（移行期間中のフォールバックとして維持）
- **CLAUDE.md**: Data Management セクションを新リポジトリ構成に更新

## 影響

- データリポジトリ（smkwlab/thesis-student-registry の data/repositories.json）への GitHub API 直接アクセスは変更なし → student-repo-management.yml / process-pending-issues.sh の自動処理は影響を受けない
- 旧パスフォールバックがあるため、thesis-student-registry#129（ツール削除）のマージ前後どちらでも動作する

Refs smkwlab/thesis-student-registry#128