### PR TITLE
refactor: point process-pending-issues.sh at data/registry.json

### DIFF
--- a/scripts/process-pending-issues.sh
+++ b/scripts/process-pending-issues.sh
@@ -274,9 +274,9 @@ prepare_registry() {
         return 1
     fi
     
-    # 書き込み権限の具体的確認（repositories.jsonファイルアクセステスト）
-    if ! gh api repos/smkwlab/thesis-student-registry/contents/data/repositories.json >/dev/null 2>&1; then
-        log_error "repositories.jsonへのアクセスに失敗しました"
+    # 書き込み権限の具体的確認（registry.jsonファイルアクセステスト）
+    if ! gh api repos/smkwlab/thesis-student-registry/contents/data/registry.json >/dev/null 2>&1; then
+        log_error "registry.jsonへのアクセスに失敗しました"
         log_error "ファイルの読み取り権限を確認してください"
         return 1
     fi
@@ -1656,10 +1656,10 @@ update_thesis_student_registry() {
     # Issue作成者のGitHub usernameを取得
     local github_username="${CURRENT_ISSUE_AUTHOR:-unknown}"
     
-    # 現在のrepositories.jsonを取得
+    # 現在のregistry.jsonを取得
     local current_json
-    if ! current_json=$(gh api repos/smkwlab/thesis-student-registry/contents/data/repositories.json --jq '.content' | base64 -d 2>/dev/null); then
-        log_error "repositories.json の取得に失敗: $repo_name"
+    if ! current_json=$(gh api repos/smkwlab/thesis-student-registry/contents/data/registry.json --jq '.content' | base64 -d 2>/dev/null); then
+        log_error "registry.json の取得に失敗: $repo_name"
         return 1
     fi
     
@@ -1695,7 +1695,7 @@ EOF
     
     # GitHub APIで更新
     local sha
-    if ! sha=$(gh api repos/smkwlab/thesis-student-registry/contents/data/repositories.json --jq '.sha'); then
+    if ! sha=$(gh api repos/smkwlab/thesis-student-registry/contents/data/registry.json --jq '.sha'); then
         log_error "SHA取得に失敗: $repo_name"
         return 1
     fi
@@ -1719,7 +1719,7 @@ Processed via automated issue processor with GitHub username."
         return 1
     fi
     
-    if gh api repos/smkwlab/thesis-student-registry/contents/data/repositories.json \
+    if gh api repos/smkwlab/thesis-student-registry/contents/data/registry.json \
         --method PUT \
         --field message="$commit_message" \
         --field content="$encoded_content" \


### PR DESCRIPTION
## 概要

resolve #469

registry 改名計画の**実行順 3 番**。`scripts/process-pending-issues.sh`（Issue 駆動の学生リポジトリ作成自動化から呼ばれる本番 writer）の `data/repositories.json` 参照 8 箇所（gh api URL 4 + コメント/ログ 4）を `data/registry.json` へ置換。

## 変更内容

- `sed` による機械的置換のみ（ロジック変更なし）
- `bash -n` で構文確認済み

## merge タイミング

前提の実行順 1（smkwlab/thesis-monitor#7）・2（smkwlab/registry-manager#9）は **merge 済み**。この PR の merge 直後に実行順 4（smkwlab/thesis-student-registry#130: データ repo の `git mv`）を実施し、旧パス書き込みの窓を最小化する。

https://claude.ai/code/session_016vdeLgLyz9q2KqHpqwKrBp