### PR TITLE
refactor: resolve the registry location by convention with overrides

### DIFF
--- a/.github/workflows/student-repo-management.yml
+++ b/.github/workflows/student-repo-management.yml
@@ -18,6 +18,11 @@ jobs:
     if: >
       github.event_name == 'workflow_dispatch' ||
       contains(github.event.issue.title || '', 'リポジトリ登録依頼')
+    env:
+      # 規約: <org>/thesis-student-registry。逸脱時のみ org/repo variable
+      # REGISTRY_REPO で override（ECOSYSTEM.md: Organization-Scoped Deployment）。
+      # checkout と script の両方がこの単一定義を参照する
+      REGISTRY_REPO: ${{ vars.REGISTRY_REPO || format('{0}/thesis-student-registry', github.repository_owner) }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
@@ -26,9 +31,7 @@ jobs:
       - name: Checkout registry data repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
-          # 規約: <org>/thesis-student-registry。逸脱時のみ org/repo variable
-          # REGISTRY_REPO で override（ECOSYSTEM.md: Organization-Scoped Deployment）
-          repository: ${{ vars.REGISTRY_REPO || format('{0}/thesis-student-registry', github.repository_owner) }}
+          repository: ${{ env.REGISTRY_REPO }}
           path: thesis-student-registry
           token: ${{ secrets.ORG_ADMIN_TOKEN || secrets.GITHUB_TOKEN }}
 
@@ -70,7 +73,6 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.ORG_ADMIN_TOKEN || secrets.GITHUB_TOKEN }}
           ISSUE_BODY: ${{ github.event.issue.body }}
-          REGISTRY_REPO: ${{ vars.REGISTRY_REPO || format('{0}/thesis-student-registry', github.repository_owner) }}
         run: |
           if [ "${{ github.event_name }}" = "issues" ]; then
             # 単一Issue処理

--- a/.github/workflows/student-repo-management.yml
+++ b/.github/workflows/student-repo-management.yml
@@ -23,10 +23,12 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           token: ${{ secrets.ORG_ADMIN_TOKEN || secrets.GITHUB_TOKEN }}
-      - name: Checkout thesis-student-registry
+      - name: Checkout registry data repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
-          repository: smkwlab/thesis-student-registry
+          # 規約: <org>/thesis-student-registry。逸脱時のみ org/repo variable
+          # REGISTRY_REPO で override（ECOSYSTEM.md: Organization-Scoped Deployment）
+          repository: ${{ vars.REGISTRY_REPO || format('{0}/thesis-student-registry', github.repository_owner) }}
           path: thesis-student-registry
           token: ${{ secrets.ORG_ADMIN_TOKEN || secrets.GITHUB_TOKEN }}
 
@@ -68,6 +70,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.ORG_ADMIN_TOKEN || secrets.GITHUB_TOKEN }}
           ISSUE_BODY: ${{ github.event.issue.body }}
+          REGISTRY_REPO: ${{ vars.REGISTRY_REPO || format('{0}/thesis-student-registry', github.repository_owner) }}
         run: |
           if [ "${{ github.event_name }}" = "issues" ]; then
             # 単一Issue処理

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -90,13 +90,13 @@ scripts/
 
 **IMPORTANT**: Student data management has been consolidated into `thesis-student-registry`:
 
-- **Student registry (data)**: `thesis-student-registry/data/repositories.json` (private repo)
+- **Student registry (data)**: `thesis-student-registry/data/registry.json` (private repo)
 - **Management tool**: [smkwlab/registry-manager](https://github.com/smkwlab/registry-manager) (Elixir escript, separate repo)
 - **Monitoring tool**: [smkwlab/thesis-monitor](https://github.com/smkwlab/thesis-monitor) (Elixir escript, separate repo)
 
 All operations now use GitHub API for safe, atomic data management instead of local files.
-The tools read the data repository location from `~/.config/registry-manager/config.json`
-(`data_repo`) or a thesis-monitor YAML config (`data_dir`).
+The tools read the registry location from `~/.config/registry-manager/config.json`
+(`registry_repo`) or a thesis-monitor YAML config (`registry_dir`).
 
 ## Document Type Configuration
 

--- a/create-repo/common-lib.sh
+++ b/create-repo/common-lib.sh
@@ -19,6 +19,11 @@ readonly NC='\033[0m'
 
 # デフォルト設定
 readonly DEFAULT_ORG="smkwlab"
+# リポジトリ名の規約（org 部分は実行時に導出。ECOSYSTEM.md の
+# Organization-Scoped Deployment 原則を参照）。env で上書き可能
+REGISTRY_REPO_NAME="${REGISTRY_REPO_NAME:-thesis-student-registry}"
+TOOLS_REPO_NAME="${TOOLS_REPO_NAME:-thesis-management-tools}"
+readonly REGISTRY_REPO_NAME TOOLS_REPO_NAME
 readonly STUDENT_ID_PATTERN='^k[0-9]{2}(rs|jk|gjk)[0-9]+$'
 
 # ================================
@@ -473,7 +478,7 @@ create_repository_issue() {
     
     local issue_number
     if issue_number=$(gh issue create \
-        --repo "${organization}/thesis-management-tools" \
+        --repo "${organization}/${TOOLS_REPO_NAME}" \
         --title "📋 リポジトリ登録依頼: ${organization}/${repo_name}" \
         --body "$issue_body" 2>&1 | grep -oE '[0-9]+$'); then
         
@@ -509,7 +514,7 @@ generate_issue_body() {
 ### 一括処理オプション
 複数の学生を一括処理する場合：
 \`\`\`bash
-cd thesis-management-tools/scripts
+cd ${TOOLS_REPO_NAME}/scripts
 # GitHub Actionsの自動処理を利用
 # または手動で一括実行
 ./bulk-setup-protection.sh
@@ -763,10 +768,13 @@ run_registry_integration() {
 
     # 条件: Registryリポジトリがアクセス可能
     # 注: INDIVIDUAL_MODE のチェックは呼び出し側の責任
-    if gh repo view "${ORGANIZATION}/thesis-student-registry" &>/dev/null; then
+    if gh repo view "${ORGANIZATION}/${REGISTRY_REPO_NAME}" &>/dev/null; then
         if ! create_repository_issue "$REPO_NAME" "$STUDENT_ID" "$doc_type" "$ORGANIZATION"; then
             log_warn "Registry Manager登録でエラーが発生しました。手動で登録が必要な場合があります。"
         fi
+    else
+        # 従来はここで無言 return しており、登録漏れに誰も気づけなかった
+        log_warn "レジストリ ${ORGANIZATION}/${REGISTRY_REPO_NAME} にアクセスできないため、登録依頼をスキップしました。手動登録が必要です。"
     fi
 }
 

--- a/create-repo/setup.sh
+++ b/create-repo/setup.sh
@@ -382,6 +382,24 @@ cd "$ORIGINAL_DIR"
 # 動作モード情報と環境変数を渡す
 DOCKER_ENV_VARS="-e USER_TYPE=$USER_TYPE -e TARGET_ORG=$TARGET_ORG"
 
+# リポジトリ名規約の override をコンテナへ転送（未設定なら渡さない = 規約デフォルト）
+# DOCKER_ENV_VARS は既存慣習どおり無引用展開されるため、安全な文字のみ許可する
+valid_repo_name() {
+    case "$1" in
+        *[!A-Za-z0-9._-]*) return 1 ;;
+        "") return 1 ;;
+        *) return 0 ;;
+    esac
+}
+if [ -n "${REGISTRY_REPO_NAME:-}" ]; then
+    valid_repo_name "$REGISTRY_REPO_NAME" || { echo "❌ REGISTRY_REPO_NAME に使用できない文字が含まれています: $REGISTRY_REPO_NAME" >&2; exit 1; }
+    DOCKER_ENV_VARS="$DOCKER_ENV_VARS -e REGISTRY_REPO_NAME=$REGISTRY_REPO_NAME"
+fi
+if [ -n "${TOOLS_REPO_NAME:-}" ]; then
+    valid_repo_name "$TOOLS_REPO_NAME" || { echo "❌ TOOLS_REPO_NAME に使用できない文字が含まれています: $TOOLS_REPO_NAME" >&2; exit 1; }
+    DOCKER_ENV_VARS="$DOCKER_ENV_VARS -e TOOLS_REPO_NAME=$TOOLS_REPO_NAME"
+fi
+
 # 文書タイプ固有の環境変数を渡す
 case "$DETECTED_DOC_TYPE" in
     latex)

--- a/scripts/process-pending-issues.sh
+++ b/scripts/process-pending-issues.sh
@@ -20,7 +20,8 @@ DEFAULT_LOG_DIR="$PROJECT_ROOT/logs"
 DEFAULT_BACKUP_DIR="$PROJECT_ROOT/backups"
 
 # 実行時設定
-REPO="${REPO:-$DEFAULT_REPO}"
+# Actions では GITHUB_REPOSITORY（自 repo）から導出、ローカルのみ既定値へ fallback
+REPO="${REPO:-${GITHUB_REPOSITORY:-$DEFAULT_REPO}}"
 # 空 = 規約で解決（resolve_registry_repo）。env / --registry-repo は明示 override
 REGISTRY_REPO="${REGISTRY_REPO:-}"
 LOG_DIR="${LOG_DIR:-$DEFAULT_LOG_DIR}"

--- a/scripts/process-pending-issues.sh
+++ b/scripts/process-pending-issues.sh
@@ -13,15 +13,32 @@ PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
 
 # デフォルト設定
 DEFAULT_REPO="smkwlab/thesis-management-tools"
-DEFAULT_REGISTRY_REPO="smkwlab/thesis-student-registry"
+# レジストリリポジトリ名の規約（org 部分は実行時に導出する。ECOSYSTEM.md の
+# Organization-Scoped Deployment 原則を参照）
+REGISTRY_REPO_NAME="thesis-student-registry"
 DEFAULT_LOG_DIR="$PROJECT_ROOT/logs"
 DEFAULT_BACKUP_DIR="$PROJECT_ROOT/backups"
 
 # 実行時設定
 REPO="${REPO:-$DEFAULT_REPO}"
-REGISTRY_REPO="${REGISTRY_REPO:-$DEFAULT_REGISTRY_REPO}"
+# 空 = 規約で解決（resolve_registry_repo）。env / --registry-repo は明示 override
+REGISTRY_REPO="${REGISTRY_REPO:-}"
 LOG_DIR="${LOG_DIR:-$DEFAULT_LOG_DIR}"
 BACKUP_DIR="${BACKUP_DIR:-$DEFAULT_BACKUP_DIR}"
+
+#
+# レジストリリポジトリの解決
+# 優先順位: --registry-repo フラグ / env REGISTRY_REPO > 規約 <org>/thesis-student-registry
+# org は GitHub Actions では GITHUB_REPOSITORY_OWNER、ローカルでは --repo の owner 部分
+#
+resolve_registry_repo() {
+    if [ -n "$REGISTRY_REPO" ]; then
+        return 0
+    fi
+
+    local org="${GITHUB_REPOSITORY_OWNER:-${REPO%%/*}}"
+    REGISTRY_REPO="${org}/${REGISTRY_REPO_NAME}"
+}
 
 # モード設定
 INTERACTIVE_MODE=false
@@ -106,7 +123,8 @@ OPTIONS:
     --type TYPE            処理対象タイプ指定 (wr|sotsuron|thesis)
     --limit NUM            最大処理数制限
     --repo REPO            対象リポジトリ (default: $DEFAULT_REPO)
-    --registry-repo REPO   レジストリリポジトリ (default: $DEFAULT_REGISTRY_REPO)
+    --registry-repo REPO   レジストリリポジトリ (default: <org>/thesis-student-registry、
+                           org は GITHUB_REPOSITORY_OWNER または --repo の owner 部分)
     --log-dir DIR          ログディレクトリ (default: $DEFAULT_LOG_DIR)
     --backup-dir DIR       バックアップディレクトリ (default: $DEFAULT_BACKUP_DIR)
     -h, --help             このヘルプを表示
@@ -265,17 +283,17 @@ create_backup() {
 # thesis-student-registry の準備（GitHub API使用時は不要）
 #
 prepare_registry() {
-    log_info "GitHub API経由でthesis-student-registryを更新します"
+    log_info "GitHub API経由で $REGISTRY_REPO を更新します"
     
     # GitHub APIアクセステスト（読み取り＋書き込み権限確認）
-    if ! gh api repos/smkwlab/thesis-student-registry >/dev/null 2>&1; then
-        log_error "thesis-student-registryへのアクセスに失敗しました"
+    if ! gh api "repos/$REGISTRY_REPO" >/dev/null 2>&1; then
+        log_error "$REGISTRY_REPO へのアクセスに失敗しました"
         log_error "GitHub CLI認証またはリポジトリ権限を確認してください"
         return 1
     fi
     
     # 書き込み権限の具体的確認（registry.jsonファイルアクセステスト）
-    if ! gh api repos/smkwlab/thesis-student-registry/contents/data/registry.json >/dev/null 2>&1; then
+    if ! gh api "repos/$REGISTRY_REPO/contents/data/registry.json" >/dev/null 2>&1; then
         log_error "registry.jsonへのアクセスに失敗しました"
         log_error "ファイルの読み取り権限を確認してください"
         return 1
@@ -283,7 +301,7 @@ prepare_registry() {
     
     # 実際の書き込み権限確認（現在のユーザーの権限レベルをチェック）
     local user_permission
-    if user_permission=$(gh api repos/smkwlab/thesis-student-registry --jq '.permissions.push' 2>/dev/null); then
+    if user_permission=$(gh api "repos/$REGISTRY_REPO" --jq '.permissions.push' 2>/dev/null); then
         if [ "$user_permission" != "true" ]; then
             log_error "リポジトリへの書き込み権限がありません"
             log_error "管理者にpush権限の付与を依頼してください"
@@ -1658,7 +1676,7 @@ update_thesis_student_registry() {
     
     # 現在のregistry.jsonを取得
     local current_json
-    if ! current_json=$(gh api repos/smkwlab/thesis-student-registry/contents/data/registry.json --jq '.content' | base64 -d 2>/dev/null); then
+    if ! current_json=$(gh api "repos/$REGISTRY_REPO/contents/data/registry.json" --jq '.content' | base64 -d 2>/dev/null); then
         log_error "registry.json の取得に失敗: $repo_name"
         return 1
     fi
@@ -1695,7 +1713,7 @@ EOF
     
     # GitHub APIで更新
     local sha
-    if ! sha=$(gh api repos/smkwlab/thesis-student-registry/contents/data/registry.json --jq '.sha'); then
+    if ! sha=$(gh api "repos/$REGISTRY_REPO/contents/data/registry.json" --jq '.sha'); then
         log_error "SHA取得に失敗: $repo_name"
         return 1
     fi
@@ -1719,7 +1737,7 @@ Processed via automated issue processor with GitHub username."
         return 1
     fi
     
-    if gh api repos/smkwlab/thesis-student-registry/contents/data/registry.json \
+    if gh api "repos/$REGISTRY_REPO/contents/data/registry.json" \
         --method PUT \
         --field message="$commit_message" \
         --field content="$encoded_content" \
@@ -1830,6 +1848,9 @@ main() {
 
 # オプション解析
 parse_options "$@"
+
+# レジストリリポジトリを解決（フラグ/env > 規約）
+resolve_registry_repo
 
 # メイン処理実行
 main


### PR DESCRIPTION
## 概要

resolve #474

ECOSYSTEM.md の **Organization-Scoped Deployment 原則**（smkwlab/latex-ecosystem#95）に基づき、レジストリデータリポジトリの所在を「規約デフォルト `<org>/thesis-student-registry` + 明示 override」で解決する。org 名リテラルを実効デフォルトから排除。

## 変更内容

- **`process-pending-issues.sh`**: `DEFAULT_REGISTRY_REPO` の直書きを廃止し `resolve_registry_repo()` を新設（優先順位: `--registry-repo` / env `REGISTRY_REPO` > 規約。org は `GITHUB_REPOSITORY_OWNER` → `--repo` の owner）。**従来死んでいた `--registry-repo` フラグが実効化**。registry への gh api 全 6 箇所が解決値を消費し、ログにも解決値を表示
- **`student-repo-management.yml`**: registry checkout と script への env を**同一式** `vars.REGISTRY_REPO || format('{0}/thesis-student-registry', github.repository_owner)` で解決（checkout と書き込み先の乖離を構造的に防止）
- **`create-repo/`**: `REGISTRY_REPO_NAME` / `TOOLS_REPO_NAME` を env 上書き可能な規約定数化（直書き 3 箇所を置換）。`setup.sh` は override を検証（英数 `._-` のみ）してコンテナへ転送。登録 gate の無言 skip に警告を追加
- **CLAUDE.md**: 旧ファイル名（repositories.json）・旧 config キーの残存記述を修正

## 検証

- 4 つの解決経路を dry-run で実走: 規約（Actions 相当 env）→ 本番 registry / env override → テスト registry / `--registry-repo` → テスト registry / ローカル fallback → 本番 registry。全て期待値どおり解決しアクセスチェック通過
- `bash -n` 全ファイル、YAML parse 確認（厳密検証は CI の Validate YAML files）
- **multi-agent 敵対的レビュー実施**（3 レンズ × 検証 7 エージェント）: findings 4 → 反証 1・confirmed 3。うち 2 件（env 値検証、無言 skip 警告）は本 PR で修正済み、1 件（学生 repo 操作側の smkwlab リテラル群 = org 展開の end-to-end 未達）は **#475 として切り出し**

## スコープ外（意図的）

- 学生 repo 操作・Issue 抽出の org 直書き → #475
- `thesis-repo-manager.sh` の tools-repo 直書き、`setup.sh` の clone URL（supply-chain 論点あり）、`setup-branch-protection.sh` の分離前残骸パス → 必要になった時点で個別対応

https://claude.ai/code/session_016vdeLgLyz9q2KqHpqwKrBp