### PR TITLE
fix: make registration failures observable end to end

### DIFF
--- a/.github/workflows/student-repo-management.yml
+++ b/.github/workflows/student-repo-management.yml
@@ -103,6 +103,8 @@ jobs:
             else
               echo "❌ Issue処理失敗"
               echo "PROTECTION_SUCCESS=false" >> "$GITHUB_ENV"
+              # 失敗を run の結論に反映する（issue #473）
+              exit 1
             fi
           else
             # 一括処理モード
@@ -113,12 +115,20 @@ jobs:
             else
               echo "❌ 一括処理失敗"
               echo "PROTECTION_SUCCESS=false" >> "$GITHUB_ENV"
+              # 失敗を run の結論に反映する（issue #473）
+              exit 1
             fi
           fi
 
       - name: Summary
-        if: env.PROTECTION_SUCCESS == 'true'
+        # 失敗時もサマリを出す（step 失敗で後続が skip されないよう always）
+        if: always() && env.PROTECTION_SUCCESS != ''
         run: |
+          if [ "${PROTECTION_SUCCESS}" != "true" ]; then
+            echo "❌ 処理に失敗しました。詳細は Process repository request のログと job summary を参照してください。"
+            echo "対象Issue: #${{ github.event.issue.number }}"
+            exit 0
+          fi
           echo "✅ 処理完了サマリー"
           echo "処理されたIssue: #${{ github.event.issue.number }}"
           echo "学生ID: ${{ env.STUDENT_ID }}"

--- a/scripts/process-pending-issues.sh
+++ b/scripts/process-pending-issues.sh
@@ -286,7 +286,8 @@ create_backup() {
 prepare_registry() {
     log_info "GitHub API経由で $REGISTRY_REPO を更新します"
     
-    # GitHub APIアクセステスト（読み取り＋書き込み権限確認）
+    # GitHub APIアクセステスト（read 系 + リポジトリ push 権限の確認。
+    # fine-grained PAT の Contents write スコープ欠落までは検出できない点に注意）
     if ! gh api "repos/$REGISTRY_REPO" >/dev/null 2>&1; then
         log_error "$REGISTRY_REPO へのアクセスに失敗しました"
         log_error "GitHub CLI認証またはリポジトリ権限を確認してください"
@@ -312,7 +313,7 @@ prepare_registry() {
         log_warn "権限レベルの確認に失敗しましたが、処理を続行します"
     fi
     
-    log_success "GitHub API経由での thesis-student-registry アクセス確認完了"
+    log_success "レジストリ $REGISTRY_REPO のアクセス確認完了（read + push 権限。token の write スコープは実書き込みまで保証されない）"
     return 0
 }
 
@@ -605,12 +606,17 @@ process_issues_automatic() {
     for i in $(seq 0 $((TOTAL_ISSUES - 1))); do
         local issue=$(echo "$issues_json" | jq ".[$i]")
         
-        if ! extract_issue_info "$issue"; then
-            local extract_exit_code=$?
+        # 注意: `if ! f; then rc=$?` では rc が negation 後の 0 になるため、
+        # 戻り値は if の外で捕捉する（issue #473 レビューで発覚した既存バグ）
+        extract_issue_info "$issue"
+        local extract_exit_code=$?
+
+        if [ "$extract_exit_code" -ne 0 ]; then
             if [ "$extract_exit_code" = "2" ]; then
                 log_warn "Issue #${CURRENT_ISSUE_NUMBER}: 情報抽出エラー、エラーカウントに追加"
                 ((EXTRACTION_ERROR_COUNT++))
                 EXTRACTION_ERROR_ISSUES+=("$CURRENT_ISSUE_NUMBER")
+                comment_processing_failure "$CURRENT_ISSUE_NUMBER" "Issue から情報を抽出できませんでした"
             else
                 log_warn "Issue #${CURRENT_ISSUE_NUMBER}: 一般的な抽出失敗、スキップします"
                 ((SKIPPED_COUNT++))
@@ -621,9 +627,11 @@ process_issues_automatic() {
         log_info "処理中 ($((i + 1))/$TOTAL_ISSUES): Issue #${CURRENT_ISSUE_NUMBER} - $CURRENT_REPO_NAME"
         
         if ! check_repository_exists "$CURRENT_REPO_NAME"; then
-            log_warn "Issue #${CURRENT_ISSUE_NUMBER}: リポジトリが見つかりません: $CURRENT_REPO_NAME"
+            # 見つからない repo は放置すると green のまま滞留するため失敗として扱う（issue #473）
+            log_error "Issue #${CURRENT_ISSUE_NUMBER}: リポジトリが見つかりません: $CURRENT_REPO_NAME"
             add_issue_comment "$CURRENT_ISSUE_NUMBER" "⚠️ リポジトリが見つかりません: smkwlab/$CURRENT_REPO_NAME"
-            ((SKIPPED_COUNT++))
+            ((FAILED_COUNT++))
+            FAILED_ISSUES+=("$CURRENT_ISSUE_NUMBER")
             continue
         fi
         
@@ -634,6 +642,7 @@ process_issues_automatic() {
             ((FAILED_COUNT++))
             FAILED_ISSUES+=("$CURRENT_ISSUE_NUMBER")
             log_error "Issue #${CURRENT_ISSUE_NUMBER}: 処理失敗"
+            comment_processing_failure "$CURRENT_ISSUE_NUMBER" "ブランチ保護またはレジストリ登録の処理でエラー"
         fi
     done
     
@@ -659,12 +668,15 @@ process_issues_interactive() {
     for i in $(seq 0 $((TOTAL_ISSUES - 1))); do
         local issue=$(echo "$issues_json" | jq ".[$i]")
         
-        if ! extract_issue_info "$issue"; then
-            local extract_exit_code=$?
+        extract_issue_info "$issue"
+        local extract_exit_code=$?
+
+        if [ "$extract_exit_code" -ne 0 ]; then
             if [ "$extract_exit_code" = "2" ]; then
                 log_warn "Issue #${CURRENT_ISSUE_NUMBER}: 情報抽出エラー、エラーカウントに追加"
                 ((EXTRACTION_ERROR_COUNT++))
                 EXTRACTION_ERROR_ISSUES+=("$CURRENT_ISSUE_NUMBER")
+                comment_processing_failure "$CURRENT_ISSUE_NUMBER" "Issue から情報を抽出できませんでした"
             else
                 log_warn "Issue #${CURRENT_ISSUE_NUMBER}: 一般的な抽出失敗、スキップします"
                 ((SKIPPED_COUNT++))
@@ -682,6 +694,7 @@ process_issues_interactive() {
             1) # 処理失敗
                 ((FAILED_COUNT++))
                 FAILED_ISSUES+=("$CURRENT_ISSUE_NUMBER")
+                comment_processing_failure "$CURRENT_ISSUE_NUMBER" "ブランチ保護またはレジストリ登録の処理でエラー"
                 ;;
             2) # ユーザーが終了を選択
                 log_info "ユーザーによる処理終了"
@@ -1639,6 +1652,26 @@ process_latex_issue() {
 #
 # Issueコメント追加
 #
+# 処理失敗を依頼者にも見えるようにする（issue #473: 無言の滞留防止）
+comment_processing_failure() {
+    local issue_number="$1"
+    local reason="$2"
+    local run_url=""
+
+    # 再実行のたびに同文コメントが積もるのを防ぐ（冪等ガード）
+    if gh issue view "$issue_number" --repo "$REPO" --json comments \
+        --jq '.comments[].body' 2>/dev/null | grep -q "自動処理に失敗しました"; then
+        log_debug "Issue #${issue_number}: 失敗コメントは投稿済みのためスキップ"
+        return 0
+    fi
+
+    if [ -n "${GITHUB_RUN_ID:-}" ]; then
+        run_url=" 実行ログ: ${GITHUB_SERVER_URL:-https://github.com}/${GITHUB_REPOSITORY:-$REPO}/actions/runs/${GITHUB_RUN_ID}"
+    fi
+
+    add_issue_comment "$issue_number" "⚠️ 自動処理に失敗しました（${reason}）。管理者が対応するまでこの Issue は open のままです。${run_url}"
+}
+
 add_issue_comment() {
     local issue_number="$1"
     local comment="$2"
@@ -1738,15 +1771,18 @@ Processed via automated issue processor with GitHub username."
         return 1
     fi
     
-    if gh api "repos/$REGISTRY_REPO/contents/data/registry.json" \
+    local api_error
+    if api_error=$(gh api "repos/$REGISTRY_REPO/contents/data/registry.json" \
         --method PUT \
         --field message="$commit_message" \
         --field content="$encoded_content" \
-        --field sha="$sha" >/dev/null 2>&1; then
+        --field sha="$sha" 2>&1 >/dev/null); then
         log_debug "thesis-student-registry 更新成功: $repo_name"
         return 0
     else
         log_error "GitHub API更新に失敗: $repo_name"
+        # 権限不足(403)等の切り分けに必須のため API エラーを残す（issue #473）
+        log_error "APIエラー詳細: ${api_error}"
         return 1
     fi
 }
@@ -1845,6 +1881,42 @@ main() {
             echo "  - Issue #${error_issue}"
         done
     fi
+
+    write_step_summary
+
+    # 1 件でも失敗があれば非 0 で終了し、呼び出し側（Actions）の run を赤にする（issue #473）
+    if [ $((FAILED_COUNT + EXTRACTION_ERROR_COUNT)) -gt 0 ]; then
+        log_error "失敗 ${FAILED_COUNT} 件 / 情報抽出エラー ${EXTRACTION_ERROR_COUNT} 件のため exit 1"
+        exit 1
+    fi
+}
+
+#
+# GitHub Actions の job summary へ集計を出力（ローカル実行では no-op）
+#
+write_step_summary() {
+    [ -z "${GITHUB_STEP_SUMMARY:-}" ] && return 0
+
+    {
+        echo "## 登録処理サマリ"
+        echo ""
+        echo "| 結果 | 件数 |"
+        echo "|---|---|"
+        echo "| 処理済み | ${PROCESSED_COUNT} |"
+        echo "| スキップ | ${SKIPPED_COUNT} |"
+        echo "| 失敗 | ${FAILED_COUNT} |"
+        echo "| 情報抽出エラー | ${EXTRACTION_ERROR_COUNT} |"
+
+        if [ ${FAILED_COUNT} -gt 0 ]; then
+            echo ""
+            echo "**失敗した Issue**: $(printf '#%s ' "${FAILED_ISSUES[@]}")"
+        fi
+
+        if [ ${EXTRACTION_ERROR_COUNT} -gt 0 ]; then
+            echo ""
+            echo "**情報抽出エラーの Issue**: $(printf '#%s ' "${EXTRACTION_ERROR_ISSUES[@]}")"
+        fi
+    } >> "$GITHUB_STEP_SUMMARY"
 }
 
 # オプション解析


### PR DESCRIPTION
## 概要

resolve #473

2026 年 6 月の token 失効障害が 3 週間検知されなかった原因（全滅でも run が緑・エラー出力の握りつぶし・read しか見ない事前チェック）を各層で解消する。

## 変更内容

**script（process-pending-issues.sh）**
- 1 件でも失敗 / 抽出エラーがあれば **exit 1**（既存カウンタ FAILED_COUNT / EXTRACTION_ERROR_COUNT を終了コードに反映 — 従来はカウントするだけで常に 0 終了）
- **GITHUB_STEP_SUMMARY** に件数表 + 失敗 Issue 番号を出力（ローカルでは no-op）
- registry PUT の **stderr をログへ捕捉**（障害時に診断を阻んだ `>/dev/null 2>&1` を解消）
- precheck の文言を実態に修正（read + repo push 権限の確認であり、fine-grained PAT の write スコープまでは保証しない）
- **失敗した Issue に理由 + 実行ログ URL をコメント**（冪等ガード付き = 再実行でスパム化しない。automatic / interactive 両モード）
- repo-not-found を green スキップから**失敗扱い**に変更（6 月の滞留クラス #454 相当の再発防止）
- **既存バグ修正**: `if ! f; then rc=$?` は rc が常に 0 になるため抽出エラー分岐（return 2）が到達不能だった。両モードとも if の外で捕捉する形に修正

**workflow（student-repo-management.yml）**
- 両分岐の失敗側に `exit 1` を追加し **run を実態どおり赤に**
- Summary step を `always()` 化し、失敗時も診断を出力（dispatch 時の空 issue コンテキストにも耐性）

## 検証

- multi-agent 敵対的レビュー（opus 2 レンズ + opus 反証 4）: **findings 4 → 4 件全て confirmed・全て本 PR で修正**（うち 1 件は上記の既存 `$?` バグの発掘、bash 5.2 での実証付き）
- 実走: スキップ経路（テスト Issue #477、処理後クローズ）で exit 0 + summary 出力を確認
- ハーネス: 失敗コメント文面（run URL 付き）・失敗込み summary・exit 判定式・`$?` 修正前後の挙動差を検証
- `bash -n` / YAML parse / dry-run 回帰すべて green

https://claude.ai/code/session_016vdeLgLyz9q2KqHpqwKrBp