### PR TITLE
fix: write canonical repository_type values to the registry

### DIFF
--- a/.github/workflows/student-repo-management.yml
+++ b/.github/workflows/student-repo-management.yml
@@ -97,8 +97,8 @@ jobs:
                 echo "REPO_TYPE=wr" >> "$GITHUB_ENV"
               elif [[ "$issue_title" == *"-sotsuron"* ]]; then
                 echo "REPO_TYPE=sotsuron" >> "$GITHUB_ENV"
-              elif [[ "$issue_title" == *"-thesis"* ]]; then
-                echo "REPO_TYPE=thesis" >> "$GITHUB_ENV"
+              elif [[ "$issue_title" == *"-master"* || "$issue_title" == *"-thesis"* ]]; then
+                echo "REPO_TYPE=master" >> "$GITHUB_ENV"
               fi
             else
               echo "❌ Issue処理失敗"

--- a/create-repo/main-thesis.sh
+++ b/create-repo/main-thesis.sh
@@ -90,7 +90,12 @@ commit_and_push "Initial setup for ${THESIS_TYPE}" "0th-draft" || exit 1
 
 # Registry Manager連携（INDIVIDUAL_MODEでない場合のみ）
 if ! [[ "$INDIVIDUAL_MODE" =~ ^(true|TRUE|1|yes|YES)$ ]]; then
-    run_registry_integration "$THESIS_TYPE"
+    # registry の正式語彙へ変換（内部値 shuuron はテンプレート整理用、issue #471）
+    if [ "$THESIS_TYPE" = "shuuron" ]; then
+        run_registry_integration "master"
+    else
+        run_registry_integration "$THESIS_TYPE"
+    fi
 fi
 
 # 完了メッセージ

--- a/scripts/process-pending-issues.sh
+++ b/scripts/process-pending-issues.sh
@@ -492,6 +492,11 @@ extract_issue_info() {
     # パターン1: Issue本文から直接抽出（最も信頼性が高い）
     if [[ "$CURRENT_ISSUE_BODY" =~ リポジトリタイプ[[:space:]]*:[[:space:]]*([a-zA-Z0-9]+) ]]; then
         CURRENT_REPO_TYPE="${BASH_REMATCH[1]}"
+        # 旧語彙・別表記を registry の正式語彙へ正規化（issue #471）
+        case "$CURRENT_REPO_TYPE" in
+            shuuron|thesis) CURRENT_REPO_TYPE="master" ;;
+            poster) CURRENT_REPO_TYPE="other" ;;
+        esac
         log_debug "Issue #${CURRENT_ISSUE_NUMBER}: Issue本文から直接タイプを抽出: $CURRENT_REPO_TYPE"
     # パターン2: Issue本文のキーワードから判定
     elif [[ "$CURRENT_ISSUE_BODY" =~ 週報|weekly ]]; then
@@ -506,8 +511,8 @@ extract_issue_info() {
     elif [[ "$CURRENT_ISSUE_BODY" =~ 卒業論文|undergraduate|sotsuron ]]; then
         CURRENT_REPO_TYPE="sotsuron"
         log_debug "Issue #${CURRENT_ISSUE_NUMBER}: Issue本文キーワードから卒論タイプを判定"
-    elif [[ "$CURRENT_ISSUE_BODY" =~ 修士論文|graduate|thesis ]]; then
-        CURRENT_REPO_TYPE="thesis"
+    elif [[ "$CURRENT_ISSUE_BODY" =~ 修士論文|graduate|master ]]; then
+        CURRENT_REPO_TYPE="master"
         log_debug "Issue #${CURRENT_ISSUE_NUMBER}: Issue本文キーワードから修論タイプを判定"
     # パターン3: リポジトリ名から判定（フォールバック）
     elif [[ "$CURRENT_REPO_NAME" == *"-wr" ]]; then
@@ -519,19 +524,17 @@ extract_issue_info() {
     elif [[ "$CURRENT_REPO_NAME" == *"-sotsuron" ]]; then
         CURRENT_REPO_TYPE="sotsuron"
         log_debug "Issue #${CURRENT_ISSUE_NUMBER}: リポジトリ名から卒論タイプを判定"
-    elif [[ "$CURRENT_REPO_NAME" == *"-thesis" ]]; then
-        CURRENT_REPO_TYPE="thesis"
+    elif [[ "$CURRENT_REPO_NAME" == *"-master" || "$CURRENT_REPO_NAME" == *"-thesis" ]]; then
+        # 修論 repo の実命名は *-master（*-thesis は防御的別名）。repository_type は
+        # master（issue #471: thesis は type の語彙ではない）
+        CURRENT_REPO_TYPE="master"
         log_debug "Issue #${CURRENT_ISSUE_NUMBER}: リポジトリ名から修論タイプを判定"
     elif [[ "$CURRENT_REPO_NAME" == *"-latex" ]]; then
         CURRENT_REPO_TYPE="latex"
         log_debug "Issue #${CURRENT_ISSUE_NUMBER}: リポジトリ名からlatexタイプを判定"
-    # パターン4: 学生IDパターンから推測（最後の手段）
-    elif [[ "$CURRENT_STUDENT_ID" =~ ^k[0-9]{2}rs[0-9]+ ]]; then
-        CURRENT_REPO_TYPE="sotsuron"
-        log_debug "Issue #${CURRENT_ISSUE_NUMBER}: 学生IDパターンから卒論タイプを推測"
-    elif [[ "$CURRENT_STUDENT_ID" =~ ^k[0-9]{2}gjk[0-9]+ ]]; then
-        CURRENT_REPO_TYPE="thesis"
-        log_debug "Issue #${CURRENT_ISSUE_NUMBER}: 学生IDパターンから修論タイプを推測"
+    # 旧パターン4（学生 ID からの推測 rs→sotsuron / gjk→thesis）は誤分類の
+    # 主因だったため廃止（issue #471）。卒論・修論は命名規約 *-sotsuron /
+    # *-thesis で必ずパターン3までに判定される
     # パターン5: その他のパターンは latex と推測
     # setup-latex.sh は様々な命名規則のリポジトリに対応するため、
     # 明示的なタイプ情報がない場合は LaTeX リポジトリとして扱う
@@ -912,7 +915,7 @@ show_issue_summary() {
         sotsuron)
             echo "  種別: 論文リポジトリ（卒業論文）"
             ;;
-        thesis)
+        master)
             echo "  種別: 論文リポジトリ（修士論文）"
             ;;
         *)
@@ -967,7 +970,7 @@ show_issue_details() {
             echo "  1. thesis-student-registry への登録"
             echo "  2. Issue クローズ"
             ;;
-        ise|sotsuron|thesis)
+        ise|sotsuron|master)
             echo "  1. ブランチ保護設定 (main, review-branch)"
             echo "  2. thesis-student-registry への登録"
             echo "  3. Issue クローズ"
@@ -1034,7 +1037,7 @@ execute_issue_processing() {
                 return 1
             fi
             ;;
-        sotsuron|thesis)
+        sotsuron|master)
             echo "→ 論文リポジトリの処理を実行中..."
             if process_thesis_with_feedback; then
                 echo "✅ 処理が完了しました"
@@ -1504,13 +1507,13 @@ process_single_issue() {
         wr)
             process_weekly_report_issue
             ;;
-        sotsuron|thesis)
+        sotsuron|master)
             process_thesis_issue
             ;;
         ise)
             process_ise_issue
             ;;
-        latex)
+        latex|other)
             process_latex_issue
             ;;
         *)
@@ -1652,7 +1655,7 @@ process_latex_issue() {
     log_info "LaTeXリポジトリ処理: $CURRENT_REPO_NAME"
     
     # 1. thesis-student-registry への登録のみ（ブランチ保護なし）
-    if ! update_thesis_student_registry "$CURRENT_REPO_NAME" "$CURRENT_STUDENT_ID" "latex"; then
+    if ! update_thesis_student_registry "$CURRENT_REPO_NAME" "$CURRENT_STUDENT_ID" "$CURRENT_REPO_TYPE"; then
         log_error "thesis-student-registry への登録に失敗: $CURRENT_REPO_NAME"
         return 1
     fi

--- a/scripts/process-pending-issues.sh
+++ b/scripts/process-pending-issues.sh
@@ -511,7 +511,8 @@ extract_issue_info() {
     elif [[ "$CURRENT_ISSUE_BODY" =~ 卒業論文|undergraduate|sotsuron ]]; then
         CURRENT_REPO_TYPE="sotsuron"
         log_debug "Issue #${CURRENT_ISSUE_NUMBER}: Issue本文キーワードから卒論タイプを判定"
-    elif [[ "$CURRENT_ISSUE_BODY" =~ 修士論文|graduate|master ]]; then
+    elif [[ "$CURRENT_ISSUE_BODY" =~ 修士論文|graduate|thesis|master ]]; then
+        # 英語 thesis も修論キーワードとして受理（type としては master を書く）
         CURRENT_REPO_TYPE="master"
         log_debug "Issue #${CURRENT_ISSUE_NUMBER}: Issue本文キーワードから修論タイプを判定"
     # パターン3: リポジトリ名から判定（フォールバック）
@@ -534,7 +535,7 @@ extract_issue_info() {
         log_debug "Issue #${CURRENT_ISSUE_NUMBER}: リポジトリ名からlatexタイプを判定"
     # 旧パターン4（学生 ID からの推測 rs→sotsuron / gjk→thesis）は誤分類の
     # 主因だったため廃止（issue #471）。卒論・修論は命名規約 *-sotsuron /
-    # *-thesis で必ずパターン3までに判定される
+    # *-master（防御的別名 *-thesis）で必ずパターン3までに判定される
     # パターン5: その他のパターンは latex と推測
     # setup-latex.sh は様々な命名規則のリポジトリに対応するため、
     # 明示的なタイプ情報がない場合は LaTeX リポジトリとして扱う
@@ -1651,6 +1652,8 @@ Pull Requestベースの学習を開始してください。"; then
 #
 # LaTeXリポジトリ処理
 #
+# latex と other の両タイプを処理する（どちらもブランチ保護なし・registry 登録
+# + Issue クローズのみ。登録タイプは解決済みの CURRENT_REPO_TYPE を使用）
 process_latex_issue() {
     log_info "LaTeXリポジトリ処理: $CURRENT_REPO_NAME"
     

--- a/scripts/process-pending-issues.sh
+++ b/scripts/process-pending-issues.sh
@@ -511,8 +511,9 @@ extract_issue_info() {
     elif [[ "$CURRENT_ISSUE_BODY" =~ 卒業論文|undergraduate|sotsuron ]]; then
         CURRENT_REPO_TYPE="sotsuron"
         log_debug "Issue #${CURRENT_ISSUE_NUMBER}: Issue本文キーワードから卒論タイプを判定"
-    elif [[ "$CURRENT_ISSUE_BODY" =~ 修士論文|graduate|thesis|master ]]; then
-        # 英語 thesis も修論キーワードとして受理（type としては master を書く）
+    elif [[ "$CURRENT_ISSUE_BODY" =~ 修士論文|修論|graduate|thesis ]]; then
+        # 英語 thesis も修論キーワードとして受理（type としては master を書く）。
+        # 単語 master は「masterブランチ」等で頻出のためキーワードにしない
         CURRENT_REPO_TYPE="master"
         log_debug "Issue #${CURRENT_ISSUE_NUMBER}: Issue本文キーワードから修論タイプを判定"
     # パターン3: リポジトリ名から判定（フォールバック）


### PR DESCRIPTION
## 概要

resolve #471

調査により、registry の `thesis` 19 件に**修論が 1 件も含まれない**（全て研究会・poster・汎用 latex の誤分類）ことを確認。設計を「repository_type の正式語彙 = `sotsuron` / `master` / `wr` / `ise` / `latex` / `other`。`thesis` は repo 名 suffix・文書種別・フィルタ名のレイヤの語であり type ではない」と確定し（issue コメント参照）、TMT 側を準拠させる。

## 発見した問題（調査で裏取り）

1. 推論が修論に `master` ではなく `thesis` を書く（語彙取り違えの発生源）
2. **学生 ID フォールバック**（gjk→thesis / rs→sotsuron）が研究会 repo を片端から誤分類（19 件の主因）
3. **`shuuron` 宣言が dispatch 未対応** — 修論の自動登録は現行 main でも「不明なリポジトリタイプ」で失敗する（実修論 3 件が手動登録だった理由）
4. `poster` 宣言も同様に dispatch 未対応
5. 修論 repo の実命名は `*-master`（registry の実データ 3 件で確認）だが、名前判定は `*-thesis` を見ていた

## 変更内容

- 宣言タイプの正規化: `shuuron`/`thesis` → `master`、`poster` → `other`
- 名前判定: `*-master`（実命名）を主、`*-thesis` を防御的別名として `master`
- 学生 ID からの type 推測を廃止（未知の latex-template 派生名は従来どおりパターン 5 で `latex`）
- dispatch に `latex|other` を統合し、登録タイプはハードコード `latex` ではなく解決値を使用
- main-thesis.sh は registry へ `master` を宣言（内部値 `shuuron` はテンプレ整理用に温存）
- workflow の Summary 用 REPO_TYPE 判定を `-master` 対応に

## 検証

- 推論ハーネス 6 ケース: shuuron 宣言 / -master 命名 / poster→other / 旧 thesis 宣言 / latex / 卒論回帰 — 全て期待値
- `bash -n` × 3 ファイル、YAML parse、dry-run 回帰 green

## ロールアウト（本 PR は 1/4）

2. registry-manager 語彙（smkwlab/registry-manager#11: `latex` 追加）→ 3. 誤分類 19 件のデータ移行（latex×18 + other×1）→ 4. thesis-monitor 追跡対象の `["sotsuron","master","latex"]` 化。**merge は 2〜3 完了後**（validation が latex を受理してから）。

https://claude.ai/code/session_016vdeLgLyz9q2KqHpqwKrBp