### PR TITLE
docs: update registry config description to the unified registry_repo scheme

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -98,7 +98,8 @@ All operations now use GitHub API for safe, atomic data management instead of lo
 The tools read the registry location from `~/.config/registry-manager/config.json`
 (`registry_repo`); thesis-monitor reads the registry via the GitHub contents
 API using the same `registry_repo` key (or the `<org>/thesis-student-registry`
-convention when unset).
+convention when unset, with `<org>` taken from the `github_org` config key,
+default `smkwlab`).
 
 ## Document Type Configuration
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -96,7 +96,9 @@ scripts/
 
 All operations now use GitHub API for safe, atomic data management instead of local files.
 The tools read the registry location from `~/.config/registry-manager/config.json`
-(`registry_repo`) or a thesis-monitor YAML config (`registry_dir`).
+(`registry_repo`); thesis-monitor reads the registry via the GitHub contents
+API using the same `registry_repo` key (or the `<org>/thesis-student-registry`
+convention when unset).
 
 ## Document Type Configuration
 


### PR DESCRIPTION
## 概要

CLAUDE.md の registry 設定記述が削除済みの `registry_dir`（thesis-monitor のローカル checkout モード、thesis-monitor#20 で撤去）に言及していたため、統一後のスキーム（両ツール `registry_repo` + org 規約導出）に更新する。

## 変更内容

- CLAUDE.md の Data Management Integration 節 1 文を現状化

https://claude.ai/code/session_016vdeLgLyz9q2KqHpqwKrBp