### PR TITLE
fix: don't hard-fail registry write precheck on GitHub App tokens

### DIFF
--- a/scripts/process-pending-issues.sh
+++ b/scripts/process-pending-issues.sh
@@ -318,19 +318,21 @@ prepare_registry() {
         return 1
     fi
     
-    # 実際の書き込み権限確認（現在のユーザーの権限レベルをチェック）
-    local user_permission
-    if user_permission=$(gh api "repos/$REGISTRY_REPO" --jq '.permissions.push' 2>/dev/null); then
-        if [ "$user_permission" != "true" ]; then
-            log_error "リポジトリへの書き込み権限がありません"
-            log_error "管理者にpush権限の付与を依頼してください"
-            return 1
+    # 書き込み権限の目安確認（参考情報。実際の write は下流の API 呼び出しで検証される）。
+    # 注意: .permissions.push は collaborator（ユーザー）権限を表すフィールドで、
+    # GitHub App の installation token では true を返さない（App は installation 権限で
+    # 書き込むため）。したがって非 true を「権限なし」と断定できない。非 true は警告に留め、
+    # 実書き込みの成否に判定を委ねる（失敗すれば下流でエラーになり run が赤くなる）。
+    local push_permission
+    if push_permission=$(gh api "repos/$REGISTRY_REPO" --jq '.permissions.push' 2>/dev/null); then
+        if [ "$push_permission" != "true" ]; then
+            log_warn "push 権限フラグが true ではありません（GitHub App token では通常この表示）。実書き込みで検証されます"
         fi
     else
         log_warn "権限レベルの確認に失敗しましたが、処理を続行します"
     fi
     
-    log_success "レジストリ $REGISTRY_REPO のアクセス確認完了（read + push 権限。token の write スコープは実書き込みまで保証されない）"
+    log_success "レジストリ $REGISTRY_REPO のアクセス確認完了（read 確認済み。write は実書き込みで検証）"
     return 0
 }
 

--- a/scripts/process-pending-issues.sh
+++ b/scripts/process-pending-issues.sh
@@ -326,7 +326,7 @@ prepare_registry() {
     local push_permission
     if push_permission=$(gh api "repos/$REGISTRY_REPO" --jq '.permissions.push' 2>/dev/null); then
         if [ "$push_permission" != "true" ]; then
-            log_warn "push 権限フラグが true ではありません（GitHub App token では通常この表示）。実書き込みで検証されます"
+            log_warn "push 権限フラグが true ではありません（GitHub App トークンでは通常この表示になります）。実際の書き込み権限は下流の API 呼び出しで検証されます"
         fi
     else
         log_warn "権限レベルの確認に失敗しましたが、処理を続行します"


### PR DESCRIPTION
## Summary

GitHub App token 移行（#482, resolve #472）の `workflow_dispatch` 検証で、App トークン認証自体は成功（token 発行・両リポジトリ checkout・gh 認証すべて緑）したものの、`process-pending-issues.sh` の **書き込み権限の事前チェックが App installation token と非互換**で run が失敗した。

### 原因

`prepare_registry` が `gh api repos/<registry> --jq '.permissions.push'` を `true` でゲートしていたが、**`.permissions.push` は collaborator（ユーザー）権限を表すフィールドで、GitHub App の installation token では true を返さない**（App は installation 権限で書き込むため）。App は実際には `contents: write` を持つのに、この偽陰性で `リポジトリへの書き込み権限がありません` として exit 1 していた。旧 PAT はユーザー扱いで `push: true` を返すため通っていた。

### 修正

非 `true` を **hard failure から warning に格下げ**。実際の write は下流の GitHub API 呼び出しで検証され、真に権限が無ければそこで失敗して run が赤くなる（#473）。read アクセスチェック（上段）は App トークンでも有効なので不変。

## Test plan

- [x] `bash -n`（構文）pass
- [x] 0 件時は `未処理のIssueは見つかりませんでした` → `return 0`（成功）となる経路を確認
- [ ] merge 後、`workflow_dispatch`（一括処理モード）を再実行し、run が緑になることを確認

## 背景

- 認証の緑ステップ: Generate GitHub App token / Checkout repository / Checkout registry data repository / Setup GitHub CLI(gh auth status) — App トークンでの cross-repo 認証は既に成立
- 失敗ステップ: Process repository request（本 PR で修正）

Refs #472, #482