### PR TITLE
fix: 登録依頼の同時多発でIssue取り違え・登録取りこぼしを解消 (#495, #496)

### DIFF
--- a/.github/workflows/student-repo-management.yml
+++ b/.github/workflows/student-repo-management.yml
@@ -77,8 +77,9 @@ jobs:
             echo "Issue #${{ github.event.issue.number }}: ${{ github.event.issue.title }}"
 
             # process-pending-issues.shを使用してIssue処理
-            # 制限を1件に設定して該当Issueのみ処理
-            if bash scripts/process-pending-issues.sh --limit 1; then
+            # トリガーとなった Issue 番号を渡して該当Issueのみ確実に処理（Bug #495）。
+            # --limit 1 は pending の先頭を拾うため同時多発時に取り違える。
+            if bash scripts/process-pending-issues.sh --issue "${{ github.event.issue.number }}"; then
               echo "✅ Issue処理完了"
               echo "PROTECTION_SUCCESS=true" >> "$GITHUB_ENV"
 

--- a/scripts/process-pending-issues.sh
+++ b/scripts/process-pending-issues.sh
@@ -367,13 +367,17 @@ fetch_pending_issues() {
             return 1
         fi
 
-        # 登録依頼/ブランチ保護設定依頼のタイトルに一致するもののみ処理対象
-        local target_json
-        target_json=$(echo "$issue_json" | jq '[select(.title | test("リポジトリ登録依頼|ブランチ保護設定依頼"))]')
-        if [ "$(echo "$target_json" | jq length)" -eq 0 ]; then
-            log_error "Issue #$TARGET_ISSUE_NUMBER は登録依頼Issueではありません（タイトル不一致）"
+        # 登録依頼/ブランチ保護設定依頼のタイトルに一致するもののみ処理対象。
+        # gh issue view は単一オブジェクトを返すため、タイトルを取り出して判定し、
+        # 後続処理が期待する配列形式へ jq '[.]' で包む。
+        local title
+        title=$(echo "$issue_json" | jq -r '.title')
+        if ! echo "$title" | grep -qE 'リポジトリ登録依頼|ブランチ保護設定依頼'; then
+            log_error "Issue #$TARGET_ISSUE_NUMBER は登録依頼Issueではありません（タイトル: $title）"
             return 1
         fi
+        local target_json
+        target_json=$(echo "$issue_json" | jq '[.]')
         echo "$target_json"
         return 0
     fi
@@ -1800,7 +1804,8 @@ update_thesis_student_registry() {
             return 1
         fi
 
-        local sha=$(echo "$contents_json" | jq -r '.sha // empty')
+        local sha
+        sha=$(echo "$contents_json" | jq -r '.sha // empty')
         if [ -z "$sha" ]; then
             log_error "SHA取得に失敗: $repo_name"
             return 1
@@ -1848,8 +1853,9 @@ Updated: $updated_at
 Processed via automated issue processor with GitHub username."
 
         # base64エンコードしてGitHub APIで更新
+        # base64 は環境により76文字ごとに改行を挿入するため tr で除去し1行に揃える
         local encoded_content
-        if ! encoded_content=$(echo "$updated_json" | base64); then
+        if ! encoded_content=$(echo "$updated_json" | base64 | tr -d '\n'); then
             log_error "base64エンコードに失敗: $repo_name"
             return 1
         fi
@@ -1865,10 +1871,11 @@ Processed via automated issue processor with GitHub username."
             return 0
         fi
 
-        # SHA競合(409/422)なら最新を取り直して再試行。gh は非2xx 時に末尾へ
-        # "(HTTP <code>)" を付けるため、その状態コードで競合を判定する。
+        # SHA競合(409)なら最新を取り直して再試行。gh は非2xx 時に末尾へ
+        # "(HTTP <code>)" を付けるため、その状態コードで競合を判定する。422 等の
+        # 検証エラーはリトライで解消しないため即失敗させ、原因特定を遅らせない。
         put_retry_count=$((put_retry_count + 1))
-        if echo "$api_error" | grep -qE 'HTTP 409|HTTP 422'; then
+        if echo "$api_error" | grep -qE 'HTTP 409'; then
             if [ "$put_retry_count" -ge "$put_max_retries" ]; then
                 log_error "registry.json 更新がSHA競合で ${put_max_retries} 回失敗: $repo_name"
                 log_error "APIエラー詳細: ${api_error}"

--- a/scripts/process-pending-issues.sh
+++ b/scripts/process-pending-issues.sh
@@ -1785,10 +1785,11 @@ update_thesis_student_registry() {
     # Issue作成者のGitHub usernameを取得
     local github_username="${CURRENT_ISSUE_AUTHOR:-unknown}"
     
-    # GET-mutate-PUT を SHA競合(409/422)に備えてリトライする（Bug #496: 並行 PUT で
+    # GET-mutate-PUT を SHA競合(409)に備えてリトライする（Bug #496: 並行 PUT で
     # 登録が失われる）。競合時は最新の content+sha を取り直し mutation を再適用して再 PUT。
     # content と sha は同一レスポンスから取り出し、取得〜PUT の競合窓を狭める。
     local put_retry_count=0
+    # 総試行回数の上限（初回 + (put_max_retries - 1) 回のリトライ = 最大5回 PUT）
     local put_max_retries=5
     while :; do
         # content と sha を1回の取得で得る（別々の GET による窓の拡大を避ける）
@@ -1812,17 +1813,21 @@ update_thesis_student_registry() {
         fi
 
         # 新しいエントリを作成（github_usernameを含む）。既存の created_at は取り直した
-        # 最新 content から拾い、並行更新による created_at の巻き戻しを防ぐ
-        local updated_at=$(date -u '+%Y-%m-%d %H:%M:%S UTC')
+        # 最新 content から拾い、並行更新による created_at の巻き戻しを防ぐ。
+        # コマンド置換を含む local は宣言と代入を分離（set -e で終了コードを握り潰さない）。
+        local updated_at
+        updated_at=$(date -u '+%Y-%m-%d %H:%M:%S UTC')
         local created_at
-        local existing_created_at=$(echo "$current_json" | jq -r --arg repo_name "$repo_name" '.[$repo_name].created_at // empty')
+        local existing_created_at
+        existing_created_at=$(echo "$current_json" | jq -r --arg repo_name "$repo_name" '.[$repo_name].created_at // empty')
         if [ -n "$existing_created_at" ] && [ "$existing_created_at" != "null" ]; then
             created_at="$existing_created_at"
         else
             created_at="$updated_at"
         fi
 
-        local new_entry=$(cat <<EOF
+        local new_entry
+        new_entry=$(cat <<EOF
 {
   "student_id": "$student_id",
   "repository_type": "$repo_type",
@@ -1877,7 +1882,7 @@ Processed via automated issue processor with GitHub username."
         put_retry_count=$((put_retry_count + 1))
         if echo "$api_error" | grep -qE 'HTTP 409'; then
             if [ "$put_retry_count" -ge "$put_max_retries" ]; then
-                log_error "registry.json 更新がSHA競合で ${put_max_retries} 回失敗: $repo_name"
+                log_error "registry.json 更新が ${put_max_retries} 回の試行すべてSHA競合で失敗: $repo_name"
                 log_error "APIエラー詳細: ${api_error}"
                 return 1
             fi

--- a/scripts/process-pending-issues.sh
+++ b/scripts/process-pending-issues.sh
@@ -67,6 +67,8 @@ BATCH_CONFIRM_MODE=false
 # フィルター設定
 FILTER_TYPE=""
 LIMIT_COUNT=""
+# 特定Issue指定（Bug #495: トリガーIssueを確実に処理。未指定なら従来の pending スキャン）
+TARGET_ISSUE_NUMBER=""
 
 # ログ設定
 TIMESTAMP=$(date +%Y%m%d_%H%M%S)
@@ -140,6 +142,7 @@ OPTIONS:
     --batch-confirm        バッチ確認モード（インタラクティブ+一括確認）
     --type TYPE            処理対象タイプ指定 (wr|sotsuron|thesis)
     --limit NUM            最大処理数制限
+    --issue NUM            特定Issue番号のみ処理（未指定時は従来通り未処理Issueを走査）
     --repo REPO            対象リポジトリ (default: $DEFAULT_REPO)
     --registry-repo REPO   レジストリリポジトリ (default: <org>/thesis-student-registry、
                            org は GITHUB_REPOSITORY_OWNER または --repo の owner 部分)
@@ -203,6 +206,14 @@ parse_options() {
                 LIMIT_COUNT="$2"
                 if ! [[ "$LIMIT_COUNT" =~ ^[0-9]+$ ]]; then
                     log_error "無効な制限数: $LIMIT_COUNT"
+                    exit 1
+                fi
+                shift 2
+                ;;
+            --issue)
+                TARGET_ISSUE_NUMBER="$2"
+                if ! [[ "$TARGET_ISSUE_NUMBER" =~ ^[0-9]+$ ]]; then
+                    log_error "無効なIssue番号: $TARGET_ISSUE_NUMBER"
                     exit 1
                 fi
                 shift 2
@@ -343,6 +354,30 @@ fetch_pending_issues() {
     log_info "未処理Issueを検索中..."
     log_debug "対象リポジトリ: $REPO"
     
+    # 特定Issue指定時は list 走査ではなく番号で直接取得する（Bug #495/#496）。
+    # gh issue list は index の eventual consistency で開いた直後の Issue を
+    # 取りこぼすことがあるため、強整合な gh issue view で対象を確実に取得する。
+    if [ -n "$TARGET_ISSUE_NUMBER" ]; then
+        log_debug "特定Issue直接取得: #$TARGET_ISSUE_NUMBER"
+        local issue_json
+        if ! issue_json=$(gh issue view "$TARGET_ISSUE_NUMBER" \
+            --repo "$REPO" \
+            --json number,title,body,createdAt,url,author 2>&1); then
+            log_error "Issue #$TARGET_ISSUE_NUMBER の取得に失敗: $issue_json"
+            return 1
+        fi
+
+        # 登録依頼/ブランチ保護設定依頼のタイトルに一致するもののみ処理対象
+        local target_json
+        target_json=$(echo "$issue_json" | jq '[select(.title | test("リポジトリ登録依頼|ブランチ保護設定依頼"))]')
+        if [ "$(echo "$target_json" | jq length)" -eq 0 ]; then
+            log_error "Issue #$TARGET_ISSUE_NUMBER は登録依頼Issueではありません（タイトル不一致）"
+            return 1
+        fi
+        echo "$target_json"
+        return 0
+    fi
+
     local issues_json
     local gh_error_output
     local retry_count=0
@@ -1746,26 +1781,43 @@ update_thesis_student_registry() {
     # Issue作成者のGitHub usernameを取得
     local github_username="${CURRENT_ISSUE_AUTHOR:-unknown}"
     
-    # 現在のregistry.jsonを取得
-    local current_json
-    if ! current_json=$(gh api "repos/$REGISTRY_REPO/contents/data/registry.json" --jq '.content' | base64 -d 2>/dev/null); then
-        log_error "registry.json の取得に失敗: $repo_name"
-        return 1
-    fi
-    
-    # 新しいエントリを作成（github_usernameを含む）
-    local updated_at=$(date -u '+%Y-%m-%d %H:%M:%S UTC')
-    
-    # 既存エントリのcreated_atを保持、新規の場合は現在時刻を使用
-    local created_at
-    local existing_created_at=$(echo "$current_json" | jq -r --arg repo_name "$repo_name" '.[$repo_name].created_at // empty')
-    if [ -n "$existing_created_at" ] && [ "$existing_created_at" != "null" ]; then
-        created_at="$existing_created_at"
-    else
-        created_at="$updated_at"
-    fi
-    
-    local new_entry=$(cat <<EOF
+    # GET-mutate-PUT を SHA競合(409/422)に備えてリトライする（Bug #496: 並行 PUT で
+    # 登録が失われる）。競合時は最新の content+sha を取り直し mutation を再適用して再 PUT。
+    # content と sha は同一レスポンスから取り出し、取得〜PUT の競合窓を狭める。
+    local put_retry_count=0
+    local put_max_retries=5
+    while :; do
+        # content と sha を1回の取得で得る（別々の GET による窓の拡大を避ける）
+        local contents_json
+        if ! contents_json=$(gh api "repos/$REGISTRY_REPO/contents/data/registry.json"); then
+            log_error "registry.json の取得に失敗: $repo_name"
+            return 1
+        fi
+
+        local current_json
+        if ! current_json=$(echo "$contents_json" | jq -r '.content' | base64 -d 2>/dev/null); then
+            log_error "registry.json のデコードに失敗: $repo_name"
+            return 1
+        fi
+
+        local sha=$(echo "$contents_json" | jq -r '.sha // empty')
+        if [ -z "$sha" ]; then
+            log_error "SHA取得に失敗: $repo_name"
+            return 1
+        fi
+
+        # 新しいエントリを作成（github_usernameを含む）。既存の created_at は取り直した
+        # 最新 content から拾い、並行更新による created_at の巻き戻しを防ぐ
+        local updated_at=$(date -u '+%Y-%m-%d %H:%M:%S UTC')
+        local created_at
+        local existing_created_at=$(echo "$current_json" | jq -r --arg repo_name "$repo_name" '.[$repo_name].created_at // empty')
+        if [ -n "$existing_created_at" ] && [ "$existing_created_at" != "null" ]; then
+            created_at="$existing_created_at"
+        else
+            created_at="$updated_at"
+        fi
+
+        local new_entry=$(cat <<EOF
 {
   "student_id": "$student_id",
   "repository_type": "$repo_type",
@@ -1775,24 +1827,17 @@ update_thesis_student_registry() {
 }
 EOF
 )
-    
-    # JSONを更新
-    local updated_json
-    if ! updated_json=$(echo "$current_json" | jq --indent 2 --arg repo_name "$repo_name" --argjson new_entry "$new_entry" '.[$repo_name] = $new_entry'); then
-        log_error "JSON更新処理に失敗: $repo_name"
-        return 1
-    fi
-    
-    # GitHub APIで更新
-    local sha
-    if ! sha=$(gh api "repos/$REGISTRY_REPO/contents/data/registry.json" --jq '.sha'); then
-        log_error "SHA取得に失敗: $repo_name"
-        return 1
-    fi
-    
-    # 個人情報保護のため学生IDをマスク化
-    local masked_student_id="${student_id:0:3}***${student_id: -2}"
-    local commit_message="Add/update repository: $repo_name
+
+        # JSONを更新
+        local updated_json
+        if ! updated_json=$(echo "$current_json" | jq --indent 2 --arg repo_name "$repo_name" --argjson new_entry "$new_entry" '.[$repo_name] = $new_entry'); then
+            log_error "JSON更新処理に失敗: $repo_name"
+            return 1
+        fi
+
+        # 個人情報保護のため学生IDをマスク化
+        local masked_student_id="${student_id:0:3}***${student_id: -2}"
+        local commit_message="Add/update repository: $repo_name
 
 Repository: $repo_name
 Student ID: $masked_student_id
@@ -1801,28 +1846,46 @@ GitHub Username: $github_username
 Updated: $updated_at
 
 Processed via automated issue processor with GitHub username."
-    
-    # base64エンコードしてGitHub APIで更新
-    local encoded_content
-    if ! encoded_content=$(echo "$updated_json" | base64); then
-        log_error "base64エンコードに失敗: $repo_name"
-        return 1
-    fi
-    
-    local api_error
-    if api_error=$(gh api "repos/$REGISTRY_REPO/contents/data/registry.json" \
-        --method PUT \
-        --field message="$commit_message" \
-        --field content="$encoded_content" \
-        --field sha="$sha" 2>&1 >/dev/null); then
-        log_debug "thesis-student-registry 更新成功: $repo_name"
-        return 0
-    else
+
+        # base64エンコードしてGitHub APIで更新
+        local encoded_content
+        if ! encoded_content=$(echo "$updated_json" | base64); then
+            log_error "base64エンコードに失敗: $repo_name"
+            return 1
+        fi
+
+        # SHA を指定して PUT（楽観ロック）
+        local api_error
+        if api_error=$(gh api "repos/$REGISTRY_REPO/contents/data/registry.json" \
+            --method PUT \
+            --field message="$commit_message" \
+            --field content="$encoded_content" \
+            --field sha="$sha" 2>&1 >/dev/null); then
+            log_debug "thesis-student-registry 更新成功: $repo_name"
+            return 0
+        fi
+
+        # SHA競合(409/422)なら最新を取り直して再試行。gh は非2xx 時に末尾へ
+        # "(HTTP <code>)" を付けるため、その状態コードで競合を判定する。
+        put_retry_count=$((put_retry_count + 1))
+        if echo "$api_error" | grep -qE 'HTTP 409|HTTP 422'; then
+            if [ "$put_retry_count" -ge "$put_max_retries" ]; then
+                log_error "registry.json 更新がSHA競合で ${put_max_retries} 回失敗: $repo_name"
+                log_error "APIエラー詳細: ${api_error}"
+                return 1
+            fi
+            local put_wait_time=$((put_retry_count * 2))
+            log_warn "registry.json 更新の競合を検出 (試行 ${put_retry_count}/${put_max_retries}): $repo_name — ${put_wait_time}秒後に再取得して再試行"
+            log_debug "APIエラー詳細: ${api_error}"
+            sleep "$put_wait_time"
+            continue
+        fi
+
         log_error "GitHub API更新に失敗: $repo_name"
         # 権限不足(403)等の切り分けに必須のため API エラーを残す（issue #473）
         log_error "APIエラー詳細: ${api_error}"
         return 1
-    fi
+    done
 }
 
 #


### PR DESCRIPTION
## 背景

登録依頼 (`リポジトリ登録依頼`) Issue が同時多発すると、各ワークフロー実行がレースして **Issue を取り違え (#495)**、また registry.json への並行 PUT で **登録が取りこぼされる (#496)**。実例: k24rs039 の Issue でトリガーされた実行が k24rs088 の Issue を処理した。

本 PR は多段の敵対的レビューを経て設計しており、当初案の「`concurrency:` グループで直列化」は **かえってデータ損失を招く**と判明したため採用していない（後述)。

## 変更内容

### #495 — トリガー Issue を確実に処理
- `process-pending-issues.sh` に **`--issue NUM` オプション**を追加し、ワークフローの単一 Issue 処理で `--limit 1` の代わりに `github.event.issue.number` を渡す。
  - `--limit 1` は pending リストの**先頭**を拾うため、同時多発時に別 Issue を処理してしまう。
- `--issue` 指定時は `gh issue list`（index の eventual consistency で開いた直後の Issue を取りこぼしうる）ではなく、**強整合な `gh issue view` で番号直引き**。
- 対象が取得できない/登録依頼タイトルに一致しない場合は **非ゼロ終了で fail loudly**（silent success で登録を落とさない)。
- オプション未指定時は従来の pending 走査のまま（`workflow_dispatch` 一括処理は不変)。

### `concurrency:` グループは追加しない（重要な設計判断）
GitHub Actions の concurrency は **FIFO キューではなくキュー深さ1**で、pending 中の古い run を次々キャンセルする。per-issue ターゲティングと組み合わせると、**10件バーストで中間の run が黙って捨てられ、その Issue は誰にも処理されない**。よって直列化には頼らず、per-issue ターゲティング + 下記リトライで正しさを担保する。registry.json はローカル checkout ではなく `gh api` 経由の**リモートファイル**で、SHA 楽観ロックで守れる。

### #496 — registry.json PUT の競合リトライ
- `update_thesis_student_registry()` の GET→mutate→PUT を **最大5回・線形バックオフのリトライループ**で包む。
- 競合時は **content+sha を同一レスポンスから取り直し**（競合窓を縮小)、mutation を再適用して再 PUT。
- リトライ判定は gh がエラー出力末尾に付ける **HTTP ステータス 409（SHA 競合)** で行う。422（検証エラー)・403（権限)等の非競合エラーはリトライしても解消しないため**即失敗**させ、切り分け用に API エラー詳細を残す (#473)。
- `created_at` は取り直した最新 content から拾い、並行更新による巻き戻しを防ぐ。sha は空/欠落をガード。

## 検証

- `bash -n` 構文チェック: パス
- `shellcheck`: 新規行に SC2155 以外の警告なし（SC2155 はファイル全体の既存慣習)
- `scripts/validate-yaml.sh`（yamllint + actionlint): パス
- ユニット確認:
  - `--issue abc` → 無効値エラーで終了
  - タイトル絞り込み: 登録依頼は一致、無関係 Issue は不一致で fail
  - HTTP 判定: 409 → リトライ、422/403/404 → 即失敗
- bash 3.2 互換（連想配列・mapfile 不使用、`set -e` 下でも `if` 内で gh の非ゼロを捕捉)

Closes #495
Closes #496