### PR TITLE
fix: parameterize organization in setup.sh for multi-org deployment (#498)

### DIFF
--- a/create-repo/setup.sh
+++ b/create-repo/setup.sh
@@ -21,7 +21,8 @@ DEFAULT_ORG="${DEFAULT_ORG:-smkwlab}"
 # このスクリプトが内部で clone する thesis-management-tools の取得元。
 # 配布元 org（＝ DEFAULT_ORG）が既定。学生リポジトリの作成先である TARGET_ORG は
 # 個人アカウントにもなり得るためここでは使わない。owner / repo 名は git clone の
-# URL に埋め込むため、安全な文字のみ許可する。
+# URL に埋め込むため、安全な文字のみ許可する（文字種のみ検証し、連続ハイフンや
+# 長さ制限など GitHub 側の詳細な命名規則は clone 時のエラーに委ねる）。
 TOOLS_REPO_OWNER="${TOOLS_REPO_OWNER:-$DEFAULT_ORG}"
 TOOLS_REPO="${TOOLS_REPO_NAME:-thesis-management-tools}"
 case "$TOOLS_REPO_OWNER" in
@@ -255,7 +256,9 @@ detect_user_type() {
         return 0
     fi
 
-    # 対象組織のメンバーシップを確認
+    # 対象組織のメンバーシップを確認する。org が個人アカウント名の場合は
+    # /orgs/<name>/members が 404 となり individual_user と判定される
+    # （個人アカウントを作成先に指定したケースの意図どおりの挙動）。
     if gh api "orgs/$org/members/$current_user" >/dev/null 2>&1; then
         echo "organization_member"
     else
@@ -275,8 +278,15 @@ fi
 
 # TARGET_ORG（対象組織）の設定
 if [ "$USER_TYPE" = "individual_user" ]; then
-    # 個人ユーザーの場合、デフォルトを個人アカウントに設定
-    TARGET_ORG="${TARGET_ORG:-$CURRENT_USER}"
+    # 個人アカウントに作成する。INDIVIDUAL_MODE が明示指定された場合は
+    # 「個人アカウントに作成する」契約を優先し、TARGET_ORG の明示値があっても
+    # 本人アカウントへ上書きする（矛盾した指定を安全側に倒す）。それ以外は
+    # 明示された TARGET_ORG を尊重し、未指定なら本人アカウントを既定にする。
+    if [[ "${INDIVIDUAL_MODE:-false}" =~ ^(true|TRUE|1|yes|YES)$ ]]; then
+        TARGET_ORG="$CURRENT_USER"
+    else
+        TARGET_ORG="${TARGET_ORG:-$CURRENT_USER}"
+    fi
     echo "👤 個人ユーザーモードで実行中"
     echo "   作成先: $TARGET_ORG (個人アカウント)"
 else

--- a/create-repo/setup.sh
+++ b/create-repo/setup.sh
@@ -39,6 +39,15 @@ case "$TOOLS_REPO" in
         exit 1 ;;
 esac
 TOOLS_CLONE_URL="${TOOLS_CLONE_URL:-https://github.com/${TOOLS_REPO_OWNER}/${TOOLS_REPO}.git}"
+# TOOLS_CLONE_URL は完全上書きを許すため、git clone へ渡す前にスキームを検証する。
+# https:// / git@ 以外（ext:: や file:// 等の危険なスキーム、先頭 "-" による git の
+# 引数注入）を拒否する。既定値も https:// で始まるため通常運用に影響はない。
+case "$TOOLS_CLONE_URL" in
+    https://*|git@*) ;;
+    *)
+        echo "❌ TOOLS_CLONE_URL は https:// または git@ で始まる必要があります: $TOOLS_CLONE_URL" >&2
+        exit 1 ;;
+esac
 
 # ================================
 # バージョン固定（再現性・安全性）
@@ -311,6 +320,8 @@ fi
 # メンバーである組織でもない場合、そこにはリポジトリを作成できないため停止する。
 # （旧実装は「TARGET_ORG == CURRENT_USER」の等値のみを許可していたため、実在の
 # 組織を指定すると必ず不整合と判定されていた。実メンバーシップ判定に置き換える。）
+# なお INDIVIDUAL_MODE 有効時は上のブロックで TARGET_ORG=$CURRENT_USER に確定する
+# ため、この妥当性チェックは等値で必ずスキップされる。
 if [ "$TARGET_ORG" != "$CURRENT_USER" ]; then
     if ! gh api "orgs/$TARGET_ORG/members/$CURRENT_USER" >/dev/null 2>&1; then
         echo "⚠️ 作成先組織にアクセスできません"

--- a/create-repo/setup.sh
+++ b/create-repo/setup.sh
@@ -17,6 +17,22 @@ fi
 # fork 側で書き換えるか、実行時に DEFAULT_ORG 環境変数で指定する。組織メンバー
 # 判定・組織ユーザーの既定作成先・案内文の URL がこの値に追従する。
 DEFAULT_ORG="${DEFAULT_ORG:-smkwlab}"
+# 組織 / アカウント名は gh api のパス（orgs/<org>/members/...）に埋め込むため、
+# GitHub のログイン/組織名の文字種（英数字とハイフン）で検証する。
+case "$DEFAULT_ORG" in
+    ""|*[!A-Za-z0-9-]*)
+        echo "❌ DEFAULT_ORG に使用できない文字が含まれています: $DEFAULT_ORG" >&2
+        exit 1 ;;
+esac
+# TARGET_ORG が env で明示指定されている場合も、同じく gh api のパスに使う前に検証する
+# （未指定＝空は後段で既定へ解決するのでここでは許容）。
+if [ -n "${TARGET_ORG:-}" ]; then
+    case "$TARGET_ORG" in
+        *[!A-Za-z0-9-]*)
+            echo "❌ TARGET_ORG に使用できない文字が含まれています: $TARGET_ORG" >&2
+            exit 1 ;;
+    esac
+fi
 
 # このスクリプトが内部で clone する thesis-management-tools の取得元。
 # 配布元 org（＝ DEFAULT_ORG）が既定。学生リポジトリの作成先である TARGET_ORG は

--- a/create-repo/setup.sh
+++ b/create-repo/setup.sh
@@ -11,6 +11,32 @@ if [ "${DEBUG:-0}" = "1" ]; then
 fi
 
 # ================================
+# 組織・ツールリポジトリ設定（他 org 展開対応）
+# ================================
+# デプロイ先の既定組織。smkwlab 以外の org で運用する場合は、この既定値を
+# fork 側で書き換えるか、実行時に DEFAULT_ORG 環境変数で指定する。組織メンバー
+# 判定・組織ユーザーの既定作成先・案内文の URL がこの値に追従する。
+DEFAULT_ORG="${DEFAULT_ORG:-smkwlab}"
+
+# このスクリプトが内部で clone する thesis-management-tools の取得元。
+# 配布元 org（＝ DEFAULT_ORG）が既定。学生リポジトリの作成先である TARGET_ORG は
+# 個人アカウントにもなり得るためここでは使わない。owner / repo 名は git clone の
+# URL に埋め込むため、安全な文字のみ許可する。
+TOOLS_REPO_OWNER="${TOOLS_REPO_OWNER:-$DEFAULT_ORG}"
+TOOLS_REPO="${TOOLS_REPO_NAME:-thesis-management-tools}"
+case "$TOOLS_REPO_OWNER" in
+    ""|*[!A-Za-z0-9-]*)
+        echo "❌ TOOLS_REPO_OWNER に使用できない文字が含まれています: $TOOLS_REPO_OWNER" >&2
+        exit 1 ;;
+esac
+case "$TOOLS_REPO" in
+    ""|*[!A-Za-z0-9._-]*)
+        echo "❌ TOOLS_REPO_NAME に使用できない文字が含まれています: $TOOLS_REPO" >&2
+        exit 1 ;;
+esac
+TOOLS_CLONE_URL="${TOOLS_CLONE_URL:-https://github.com/${TOOLS_REPO_OWNER}/${TOOLS_REPO}.git}"
+
+# ================================
 # バージョン固定（再現性・安全性）
 # ================================
 # このスクリプトが内部で clone・利用する thesis-management-tools の参照先（ref）。
@@ -53,17 +79,17 @@ if [ -z "$DOC_TYPE" ]; then
     echo "❌ 文書タイプが指定されていません"
     echo ""
     echo "使用例："
-    echo "  /bin/bash -c \"\$(curl -fsSL https://raw.githubusercontent.com/smkwlab/thesis-management-tools/main/create-repo/setup.sh)\" bash thesis"
-    echo "  /bin/bash -c \"\$(curl -fsSL https://raw.githubusercontent.com/smkwlab/thesis-management-tools/main/create-repo/setup.sh)\" bash wr"
-    echo "  /bin/bash -c \"\$(curl -fsSL https://raw.githubusercontent.com/smkwlab/thesis-management-tools/main/create-repo/setup.sh)\" bash latex"
-    echo "  /bin/bash -c \"\$(curl -fsSL https://raw.githubusercontent.com/smkwlab/thesis-management-tools/main/create-repo/setup.sh)\" bash ise"
-    echo "  /bin/bash -c \"\$(curl -fsSL https://raw.githubusercontent.com/smkwlab/thesis-management-tools/main/create-repo/setup.sh)\" bash poster"
+    echo "  /bin/bash -c \"\$(curl -fsSL https://raw.githubusercontent.com/${TOOLS_REPO_OWNER}/${TOOLS_REPO}/main/create-repo/setup.sh)\" bash thesis"
+    echo "  /bin/bash -c \"\$(curl -fsSL https://raw.githubusercontent.com/${TOOLS_REPO_OWNER}/${TOOLS_REPO}/main/create-repo/setup.sh)\" bash wr"
+    echo "  /bin/bash -c \"\$(curl -fsSL https://raw.githubusercontent.com/${TOOLS_REPO_OWNER}/${TOOLS_REPO}/main/create-repo/setup.sh)\" bash latex"
+    echo "  /bin/bash -c \"\$(curl -fsSL https://raw.githubusercontent.com/${TOOLS_REPO_OWNER}/${TOOLS_REPO}/main/create-repo/setup.sh)\" bash ise"
+    echo "  /bin/bash -c \"\$(curl -fsSL https://raw.githubusercontent.com/${TOOLS_REPO_OWNER}/${TOOLS_REPO}/main/create-repo/setup.sh)\" bash poster"
     echo ""
     echo "学籍番号を指定する場合（環境変数）："
-    echo "  STUDENT_ID=k21rs001 /bin/bash -c \"\$(curl -fsSL https://raw.githubusercontent.com/smkwlab/thesis-management-tools/main/create-repo/setup.sh)\" bash thesis"
+    echo "  STUDENT_ID=k21rs001 /bin/bash -c \"\$(curl -fsSL https://raw.githubusercontent.com/${TOOLS_REPO_OWNER}/${TOOLS_REPO}/main/create-repo/setup.sh)\" bash thesis"
     echo ""
     echo "環境変数での指定も可能："
-    echo "  DOC_TYPE=thesis /bin/bash -c \"\$(curl -fsSL https://raw.githubusercontent.com/smkwlab/thesis-management-tools/main/create-repo/setup.sh)\""
+    echo "  DOC_TYPE=thesis /bin/bash -c \"\$(curl -fsSL https://raw.githubusercontent.com/${TOOLS_REPO_OWNER}/${TOOLS_REPO}/main/create-repo/setup.sh)\""
     echo ""
     exit 1
 fi
@@ -213,21 +239,24 @@ fi
 echo "✅ GitHub認証済み (ユーザー: $CURRENT_USER)"
 
 # ユーザータイプ判定関数
+# 第2引数で渡された組織のメンバーシップを確認する（既定は DEFAULT_ORG、
+# TARGET_ORG が明示指定されていれば呼び出し側でそちらを渡す）。
 detect_user_type() {
     local current_user="$1"
-    
+    local org="$2"
+
     if [ "${DEBUG:-0}" = "1" ]; then
-        echo "🔍 ユーザータイプを判定中: $current_user"
+        echo "🔍 ユーザータイプを判定中: $current_user (組織: $org)"
     fi
-    
+
     # INDIVIDUAL_MODE環境変数による明示的指定
     if [[ "${INDIVIDUAL_MODE:-false}" =~ ^(true|TRUE|1|yes|YES)$ ]]; then
         echo "individual_user"
         return 0
     fi
-    
-    # smkwlab組織メンバーシップを確認
-    if gh api "orgs/smkwlab/members/$current_user" >/dev/null 2>&1; then
+
+    # 対象組織のメンバーシップを確認
+    if gh api "orgs/$org/members/$current_user" >/dev/null 2>&1; then
         echo "organization_member"
     else
         echo "individual_user"
@@ -235,7 +264,10 @@ detect_user_type() {
 }
 
 # ユーザータイプの判定
-USER_TYPE=$(detect_user_type "$CURRENT_USER")
+# メンバーシップ確認の対象は、TARGET_ORG が明示指定されていればその組織、
+# 無ければ既定組織 (DEFAULT_ORG)。
+MEMBERSHIP_ORG="${TARGET_ORG:-$DEFAULT_ORG}"
+USER_TYPE=$(detect_user_type "$CURRENT_USER" "$MEMBERSHIP_ORG")
 
 if [ "${DEBUG:-0}" = "1" ]; then
     echo "🔍 判定結果: $USER_TYPE"
@@ -248,24 +280,28 @@ if [ "$USER_TYPE" = "individual_user" ]; then
     echo "👤 個人ユーザーモードで実行中"
     echo "   作成先: $TARGET_ORG (個人アカウント)"
 else
-    # 組織ユーザーの場合、従来通り
-    TARGET_ORG="${TARGET_ORG:-smkwlab}"
+    # 組織ユーザーの場合、既定組織 (DEFAULT_ORG) を作成先とする
+    TARGET_ORG="${TARGET_ORG:-$DEFAULT_ORG}"
     echo "🏢 組織ユーザーモードで実行中"
     echo "   作成先: $TARGET_ORG (組織)"
 fi
 
-# TARGET_ORG が指定されている場合、アカウントの整合性をチェック
-if [ -n "$TARGET_ORG" ] && [ "$TARGET_ORG" != "smkwlab" ]; then
-    if [ "$CURRENT_USER" != "$TARGET_ORG" ]; then
-        echo "⚠️ アカウント不整合が検出されました"
+# 作成先の妥当性チェック：
+# TARGET_ORG が本人の個人アカウント (== CURRENT_USER) でも、CURRENT_USER が
+# メンバーである組織でもない場合、そこにはリポジトリを作成できないため停止する。
+# （旧実装は「TARGET_ORG == CURRENT_USER」の等値のみを許可していたため、実在の
+# 組織を指定すると必ず不整合と判定されていた。実メンバーシップ判定に置き換える。）
+if [ "$TARGET_ORG" != "$CURRENT_USER" ]; then
+    if ! gh api "orgs/$TARGET_ORG/members/$CURRENT_USER" >/dev/null 2>&1; then
+        echo "⚠️ 作成先組織にアクセスできません"
         echo "  指定組織: $TARGET_ORG"
         echo "  現在のアカウント: $CURRENT_USER"
         echo ""
-        echo "以下のコマンドでアカウントを切り替えてください："
-        echo "  gh auth switch --user $TARGET_ORG"
+        echo "$CURRENT_USER は $TARGET_ORG のメンバーではないか、組織が存在しません。"
         echo ""
-        echo "または、現在のアカウントで個人リポジトリとして作成："
-        echo "  TARGET_ORG=$CURRENT_USER $0"
+        echo "対処法："
+        echo "  - メンバーのアカウントに切り替える: gh auth switch --user <member>"
+        echo "  - 現在のアカウントで個人リポジトリとして作成: TARGET_ORG=$CURRENT_USER $0"
         exit 1
     fi
 fi
@@ -306,8 +342,8 @@ ORIGINAL_DIR=$(pwd)
 
 echo "📥 リポジトリを取得中..."
 
-if ! git clone https://github.com/smkwlab/thesis-management-tools.git "$TEMP_DIR" 2>/dev/null; then
-    echo "❌ リポジトリのクローンに失敗しました"
+if ! git clone "$TOOLS_CLONE_URL" "$TEMP_DIR" 2>/dev/null; then
+    echo "❌ リポジトリのクローンに失敗しました ($TOOLS_CLONE_URL)"
     exit 1
 fi
 
@@ -342,7 +378,7 @@ if [ "$SETUP_REF" != "main" ]; then
         # フォールバックは再現性・監査性を損なうため、エラーとして終了する。
         echo "❌ 指定された参照 ($SETUP_REF) が見つかりません。"
         echo "   タグ名・コミットSHA・ブランチ名が正しいか確認してください。"
-        echo "   利用可能なバージョン: https://github.com/smkwlab/thesis-management-tools/releases"
+        echo "   利用可能なバージョン: https://github.com/${TOOLS_REPO_OWNER}/${TOOLS_REPO}/releases"
         exit 1
     fi
 

--- a/create-repo/setup.sh
+++ b/create-repo/setup.sh
@@ -24,6 +24,9 @@ DEFAULT_ORG="${DEFAULT_ORG:-smkwlab}"
 # URL に埋め込むため、安全な文字のみ許可する（文字種のみ検証し、連続ハイフンや
 # 長さ制限など GitHub 側の詳細な命名規則は clone 時のエラーに委ねる）。
 TOOLS_REPO_OWNER="${TOOLS_REPO_OWNER:-$DEFAULT_ORG}"
+# TOOLS_REPO は env 変数 TOOLS_REPO_NAME を解決した内部変数（既定を適用済み）。
+# TOOLS_REPO_NAME 自体は「ユーザーが指定した時のみコンテナへ転送する」判定に
+# 後段（$TOOLS_REPO_NAME の有無チェック）で使うため、別名のまま残す。
 TOOLS_REPO="${TOOLS_REPO_NAME:-thesis-management-tools}"
 case "$TOOLS_REPO_OWNER" in
     ""|*[!A-Za-z0-9-]*)
@@ -268,7 +271,9 @@ detect_user_type() {
 
 # ユーザータイプの判定
 # メンバーシップ確認の対象は、TARGET_ORG が明示指定されていればその組織、
-# 無ければ既定組織 (DEFAULT_ORG)。
+# 無ければ既定組織 (DEFAULT_ORG)。TARGET_ORG が明示指定されている場合は、
+# ここ（型判定）と後段の作成先妥当性チェックの 2 か所でメンバーシップ API を
+# 呼ぶ。型判定とアクセス検証は別関心なので、冗長 1 回は許容し分離を優先する。
 MEMBERSHIP_ORG="${TARGET_ORG:-$DEFAULT_ORG}"
 USER_TYPE=$(detect_user_type "$CURRENT_USER" "$MEMBERSHIP_ORG")
 
@@ -283,6 +288,11 @@ if [ "$USER_TYPE" = "individual_user" ]; then
     # 本人アカウントへ上書きする（矛盾した指定を安全側に倒す）。それ以外は
     # 明示された TARGET_ORG を尊重し、未指定なら本人アカウントを既定にする。
     if [[ "${INDIVIDUAL_MODE:-false}" =~ ^(true|TRUE|1|yes|YES)$ ]]; then
+        # 矛盾指定（INDIVIDUAL_MODE=true かつ TARGET_ORG=組織）は、無視される側を
+        # 明示してからユーザーへ知らせる。
+        if [ -n "${TARGET_ORG:-}" ] && [ "$TARGET_ORG" != "$CURRENT_USER" ]; then
+            echo "⚠️ INDIVIDUAL_MODE が有効なため TARGET_ORG=$TARGET_ORG を無視し、個人アカウント ($CURRENT_USER) を使用します"
+        fi
         TARGET_ORG="$CURRENT_USER"
     else
         TARGET_ORG="${TARGET_ORG:-$CURRENT_USER}"

--- a/docs/CLAUDE-DEVELOPMENT.md
+++ b/docs/CLAUDE-DEVELOPMENT.md
@@ -57,8 +57,11 @@ variables (defaults preserve smkwlab behavior):
 | `TOOLS_CLONE_URL` | `https://github.com/<owner>/<repo>.git` | Full override of the clone URL (e.g. GitHub Enterprise / mirror). |
 
 `TOOLS_REPO_OWNER` / `TOOLS_REPO_NAME` are validated against a safe character
-set before being embedded in the clone URL. See the ecosystem-wide
-[Multi-Org Deployment Guide](https://github.com/smkwlab/latex-ecosystem/blob/main/docs/MULTI-ORG-DEPLOYMENT.md).
+set (character class only) before being embedded in the clone URL; GitHub's
+finer naming rules are left to the clone-time error. See the ecosystem-wide
+[Multi-Org Deployment Guide](https://github.com/smkwlab/latex-ecosystem/blob/main/docs/MULTI-ORG-DEPLOYMENT.md)
+(canonical upstream reference; the URL stays on the smkwlab origin repo
+regardless of deployment org).
 
 **Security Features:**
 - No persistent authentication storage in containers

--- a/docs/CLAUDE-DEVELOPMENT.md
+++ b/docs/CLAUDE-DEVELOPMENT.md
@@ -54,7 +54,7 @@ variables (defaults preserve smkwlab behavior):
 | `TARGET_ORG` | derived | Explicit creation target. If it is not the user's own account, membership in it is verified. Individual users default to their own account. |
 | `TOOLS_REPO_OWNER` | `$DEFAULT_ORG` | Owner of the `thesis-management-tools` repo cloned internally. Distinct from `TARGET_ORG` (which may be a personal account). |
 | `TOOLS_REPO_NAME` | `thesis-management-tools` | Repo name cloned internally and forwarded to the container for registry integration. |
-| `TOOLS_CLONE_URL` | `https://github.com/<owner>/<repo>.git` | Full override of the clone URL (e.g. GitHub Enterprise / mirror). |
+| `TOOLS_CLONE_URL` | `https://github.com/<owner>/<repo>.git` | Full override of the clone URL (e.g. GitHub Enterprise / mirror). Must start with `https://` or `git@`. When set alone, also set `TOOLS_REPO_OWNER`/`TOOLS_REPO_NAME` so the usage/releases URLs in help text match the actual clone source. |
 
 `TOOLS_REPO_OWNER` / `TOOLS_REPO_NAME` are validated against a safe character
 set (character class only) before being embedded in the clone URL; GitHub's

--- a/docs/CLAUDE-DEVELOPMENT.md
+++ b/docs/CLAUDE-DEVELOPMENT.md
@@ -32,13 +32,33 @@ The authentication system provides a secure and user-friendly experience:
 
 **Multiple Account Support:**
 ```bash
-# Automatic account detection with conflict resolution
+# Validate that the current account can create in TARGET_ORG:
+# either it is the user's own account, or the user is a member of that org.
 CURRENT_USER=$(gh api user --jq .login)
-if [ "$CURRENT_USER" != "$TARGET_ORG" ]; then
-    # Provide clear guidance for account switching
-    echo "gh auth switch --user $TARGET_ORG"
+if [ "$TARGET_ORG" != "$CURRENT_USER" ] \
+   && ! gh api "orgs/$TARGET_ORG/members/$CURRENT_USER" >/dev/null 2>&1; then
+    # Not a member (or org does not exist): guide account switching
+    echo "gh auth switch --user <member>"
 fi
 ```
+
+### Organization Configuration (multi-org deployment)
+
+`setup.sh` resolves the target organization without hardcoding `smkwlab`, so
+the tool can be forked and deployed to another org. Override via environment
+variables (defaults preserve smkwlab behavior):
+
+| Variable | Default | Purpose |
+|----------|---------|---------|
+| `DEFAULT_ORG` | `smkwlab` | Org checked for membership and used as the default creation target for organization members. Forks set this (via env or by editing the embedded default). |
+| `TARGET_ORG` | derived | Explicit creation target. If it is not the user's own account, membership in it is verified. Individual users default to their own account. |
+| `TOOLS_REPO_OWNER` | `$DEFAULT_ORG` | Owner of the `thesis-management-tools` repo cloned internally. Distinct from `TARGET_ORG` (which may be a personal account). |
+| `TOOLS_REPO_NAME` | `thesis-management-tools` | Repo name cloned internally and forwarded to the container for registry integration. |
+| `TOOLS_CLONE_URL` | `https://github.com/<owner>/<repo>.git` | Full override of the clone URL (e.g. GitHub Enterprise / mirror). |
+
+`TOOLS_REPO_OWNER` / `TOOLS_REPO_NAME` are validated against a safe character
+set before being embedded in the clone URL. See the ecosystem-wide
+[Multi-Org Deployment Guide](https://github.com/smkwlab/latex-ecosystem/blob/main/docs/MULTI-ORG-DEPLOYMENT.md).
 
 **Security Features:**
 - No persistent authentication storage in containers


### PR DESCRIPTION
## 概要

学生の入口 `create-repo/setup.sh` に集中していた `smkwlab` ハードコードを解消し、他 org へ fork 展開しても動作するようにする。他 org 展開の横断調査（latex-ecosystem #105）で本スクリプトが最大のブロッカーと特定されていた。

Resolves #498

## 変更内容

**機能ブロッカー 3 点（Issue 記載）:**

- **org メンバー判定 (旧 230行)**: `orgs/smkwlab/members/...` 固定を廃止。`detect_user_type` に対象組織を引数で渡し、`DEFAULT_ORG`（既定 smkwlab・env 上書き可）、`TARGET_ORG` 明示時はそれを使う。他 org のメンバーが「個人ユーザー」と誤判定され組織フローが静かにスキップされる問題を解消
- **整合性ガード (旧 258-271行)**: `CURRENT_USER == TARGET_ORG` の等値要求を廃止し、「TARGET_ORG が本人アカウント、または CURRENT_USER がメンバーの組織か」を実メンバーシップ (`gh api orgs/<org>/members/<user>`) で検証。任意 org を受け入れつつ、非メンバー org / 実在しない org は actionable なメッセージで停止
- **clone 元 (旧 309行)**: `TOOLS_REPO_OWNER`（既定 `DEFAULT_ORG`）/ `TOOLS_REPO_NAME`（既定 thesis-management-tools）から導出。`TOOLS_CLONE_URL` で完全上書きも可（GHE / ミラー向け）。owner/repo は URL 埋め込み前に文字検証。※ clone 元は「ツール配布元 org」であり、個人アカウントにもなり得る `TARGET_ORG` からは意図的に導出しない（Issue 記載を正確化）

**併せて:**

- 案内文・releases URL も `DEFAULT_ORG`/`TOOLS_REPO` に追従
- `docs/CLAUDE-DEVELOPMENT.md` の旧ロジックのコード例を更新し、org override 用 env 変数（DEFAULT_ORG / TARGET_ORG / TOOLS_REPO_OWNER / TOOLS_REPO_NAME / TOOLS_CLONE_URL）を表で追記

既定値はすべて smkwlab のままで**現行挙動は不変**。fork 側は `DEFAULT_ORG` の埋め込み既定を書き換えるか env で指定する運用。

## 検証

- `bash -n` 構文チェック: OK
- gh をモックした org 解決ロジックの振る舞いテスト（7 シナリオ）を全通過:
  - smkwlab メンバー（既定・現行不変）/ 非メンバー個人 / 他 org メンバー受理 / 他 org 非メンバー拒否 / fork（DEFAULT_ORG=他org）/ 本人アカウント指定 / INDIVIDUAL_MODE 優先
- clone URL 導出・入力検証テスト: 既定・fork・owner/name/full 上書きが正しく組み立てられ、`evil.com/x#` や `a b; rm -rf` 等の不正 owner/repo は拒否

## 補足

org メンバーの経路では `detect_user_type` とガードでメンバーシップ API を各 1 回（計 2 回）呼ぶ。型判定とアクセス検証を分離した結果の冗長 1 回で、可読性を優先した。

関連: #105（他 org 展開 統括）