### PR TITLE
fix: parameterize remaining create-repo hardcodes for multi-org (#499)

### DIFF
--- a/create-repo/common-lib.sh
+++ b/create-repo/common-lib.sh
@@ -578,7 +578,7 @@ setup_latex_environment() {
     else
         log_warn "LaTeX環境は手動設定が必要"
         log_info "手動セットアップ手順:"
-        log_info "  /bin/bash -c \"\$(curl -fsSL ${aldc_url})\""
+        log_info "  /bin/bash -c \"\$(curl -fsSL \"${aldc_url}\")\""
         return 1
     fi
 }
@@ -646,6 +646,8 @@ setup_auto_assign_for_organization_members() {
         # auto-assign の reviewer/assignee。既定は smkwlab の担当者。他 org では
         # AUTO_ASSIGN_REVIEWER で上書きする（setup.sh がコンテナへ転送する）。
         # プレースホルダを sed 置換するため、GitHub ログイン文字種のみ許可する。
+        # このコンテナ側チェックは、コンテナを setup.sh 経由せず直接実行する場合にも
+        # 効かせるための防御（setup.sh 側にも同等の検証がある）。
         local reviewer="${AUTO_ASSIGN_REVIEWER:-toshi0806}"
         case "$reviewer" in
             ""|*[!A-Za-z0-9-]*)

--- a/create-repo/common-lib.sh
+++ b/create-repo/common-lib.sh
@@ -196,8 +196,9 @@ setup_git_auth() {
 }
 
 # Gitユーザー設定
+# コミット作者のメールドメインは SETUP_GIT_EMAIL_DOMAIN で上書き可能（既定 smkwlab.github.io）。
 setup_git_user() {
-    local email="${1:-setup@smkwlab.github.io}"
+    local email="${1:-setup@${SETUP_GIT_EMAIL_DOMAIN:-smkwlab.github.io}}"
     local name="${2:-Setup Tool}"
     
     git config user.email "$email"
@@ -566,14 +567,18 @@ setup_review_workflow() {
 setup_latex_environment() {
     log_info "LaTeX環境をセットアップ中..."
     
+    # aldc の取得元。既定は smkwlab の公開 aldc。他 org で独自 aldc を使う場合は
+    # ALDC_URL で上書きする（setup.sh がコンテナへ転送する）。
+    local aldc_url="${ALDC_URL:-https://raw.githubusercontent.com/smkwlab/aldc/main/aldc}"
+
     # curlでaldcスクリプトを実行（メッセージ抑制）
-    if ALDC_QUIET=1 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/smkwlab/aldc/main/aldc)" 2>/dev/null; then
+    if ALDC_QUIET=1 /bin/bash -c "$(curl -fsSL "$aldc_url")" 2>/dev/null; then
         log_info "LaTeX環境のセットアップ完了"
         return 0
     else
         log_warn "LaTeX環境は手動設定が必要"
         log_info "手動セットアップ手順:"
-        log_info "  /bin/bash -c \"\$(curl -fsSL https://raw.githubusercontent.com/smkwlab/aldc/main/aldc)\""
+        log_info "  /bin/bash -c \"\$(curl -fsSL ${aldc_url})\""
         return 1
     fi
 }
@@ -638,9 +643,19 @@ setup_auto_assign_for_organization_members() {
             log_warn "  ⚠️ テンプレートファイルが見つかりません: ${template_dir}/autoassignees.yml"
         fi
 
+        # auto-assign の reviewer/assignee。既定は smkwlab の担当者。他 org では
+        # AUTO_ASSIGN_REVIEWER で上書きする（setup.sh がコンテナへ転送する）。
+        # プレースホルダを sed 置換するため、GitHub ログイン文字種のみ許可する。
+        local reviewer="${AUTO_ASSIGN_REVIEWER:-toshi0806}"
+        case "$reviewer" in
+            ""|*[!A-Za-z0-9-]*)
+                log_error "AUTO_ASSIGN_REVIEWER が不正です（英数字とハイフンのみ）: $reviewer"
+                return 1 ;;
+        esac
         if [ -f "${template_dir}/auto_assign_myteams.yml" ]; then
-            cp "${template_dir}/auto_assign_myteams.yml" .github/
-            log_info "  ✓ .github/auto_assign_myteams.yml を追加"
+            sed "s/__AUTO_ASSIGN_REVIEWER__/${reviewer}/g" \
+                "${template_dir}/auto_assign_myteams.yml" > .github/auto_assign_myteams.yml
+            log_info "  ✓ .github/auto_assign_myteams.yml を追加 (reviewer: ${reviewer})"
         else
             log_warn "  ⚠️ テンプレートファイルが見つかりません: ${template_dir}/auto_assign_myteams.yml"
         fi
@@ -738,7 +753,7 @@ run_standard_setup() {
 
     # Git設定
     setup_git_auth || exit 1
-    setup_git_user "setup-${doc_type}@smkwlab.github.io" "${display_name} Setup Tool"
+    setup_git_user "setup-${doc_type}@${SETUP_GIT_EMAIL_DOMAIN:-smkwlab.github.io}" "${display_name} Setup Tool"
 
     # 注意: テンプレートファイルの整理（CLAUDE.md / docs/ / *-aldc 削除）は
     # ここでは行わない。aldc（setup_latex_environment）が latex-environment 由来の

--- a/create-repo/main-latex.sh
+++ b/create-repo/main-latex.sh
@@ -11,7 +11,10 @@ init_script_common "汎用LaTeXリポジトリセットアップツール" "📝
 
 # 設定
 ORGANIZATION=$(determine_organization)
-TEMPLATE_REPOSITORY="smkwlab/latex-template"  # 常に固定
+# latex-template は個人ユーザー（ORGANIZATION=個人アカウント）も利用する共有テンプレ
+# のため、org 追従にはせず既定を smkwlab に固定する。他 org で独自テンプレを使う場合は
+# TEMPLATE_REPO で上書きする。
+TEMPLATE_REPOSITORY="${TEMPLATE_REPO:-smkwlab/latex-template}"
 VISIBILITY="private"
 
 log_info "テンプレートリポジトリ: $TEMPLATE_REPOSITORY"

--- a/create-repo/main-poster.sh
+++ b/create-repo/main-poster.sh
@@ -11,7 +11,10 @@ init_script_common "学会ポスターリポジトリセットアップツール
 
 # 設定
 ORGANIZATION=$(determine_organization)
-TEMPLATE_REPOSITORY="smkwlab/poster-template"  # 常に固定
+# poster-template は個人ユーザー（ORGANIZATION=個人アカウント）も利用する共有テンプレ
+# のため、org 追従にはせず既定を smkwlab に固定する。他 org で独自テンプレを使う場合は
+# TEMPLATE_REPO で上書きする。
+TEMPLATE_REPOSITORY="${TEMPLATE_REPO:-smkwlab/poster-template}"
 VISIBILITY="private"
 
 log_info "テンプレートリポジトリ: $TEMPLATE_REPOSITORY"

--- a/create-repo/setup.sh
+++ b/create-repo/setup.sh
@@ -502,7 +502,11 @@ if [ -n "${ALDC_URL:-}" ]; then
         https://*) ;;
         *) echo "❌ ALDC_URL は https:// で始まる必要があります: $ALDC_URL" >&2; exit 1 ;;
     esac
-    case "$ALDC_URL" in *[[:space:]]*) echo "❌ ALDC_URL に空白は含められません: $ALDC_URL" >&2; exit 1 ;; esac
+    # 無引用展開（docker run $DOCKER_ENV_VARS）に載るため、URL 安全文字のみ許可し、
+    # 空白（単語分割）と glob 文字（* ? [）を排除する。他の転送変数と同じ流儀。
+    case "$ALDC_URL" in
+        *[!A-Za-z0-9._~:/%-]*) echo "❌ ALDC_URL に使用できない文字が含まれています: $ALDC_URL" >&2; exit 1 ;;
+    esac
     DOCKER_ENV_VARS="$DOCKER_ENV_VARS -e ALDC_URL=$ALDC_URL"
 fi
 if [ -n "${SETUP_GIT_EMAIL_DOMAIN:-}" ]; then

--- a/create-repo/setup.sh
+++ b/create-repo/setup.sh
@@ -483,6 +483,35 @@ if [ -n "${TOOLS_REPO_NAME:-}" ]; then
     DOCKER_ENV_VARS="$DOCKER_ENV_VARS -e TOOLS_REPO_NAME=$TOOLS_REPO_NAME"
 fi
 
+# 他 org 展開向けの override をコンテナへ転送（未設定なら渡さない = 既定）。
+# いずれも無引用展開に載るため、空白を含まない安全な文字種のみ許可する。
+if [ -n "${TEMPLATE_REPO:-}" ]; then
+    case "$TEMPLATE_REPO" in
+        *[!A-Za-z0-9._/-]*|"") echo "❌ TEMPLATE_REPO に使用できない文字が含まれています: $TEMPLATE_REPO" >&2; exit 1 ;;
+    esac
+    DOCKER_ENV_VARS="$DOCKER_ENV_VARS -e TEMPLATE_REPO=$TEMPLATE_REPO"
+fi
+if [ -n "${AUTO_ASSIGN_REVIEWER:-}" ]; then
+    case "$AUTO_ASSIGN_REVIEWER" in
+        *[!A-Za-z0-9-]*|"") echo "❌ AUTO_ASSIGN_REVIEWER に使用できない文字が含まれています: $AUTO_ASSIGN_REVIEWER" >&2; exit 1 ;;
+    esac
+    DOCKER_ENV_VARS="$DOCKER_ENV_VARS -e AUTO_ASSIGN_REVIEWER=$AUTO_ASSIGN_REVIEWER"
+fi
+if [ -n "${ALDC_URL:-}" ]; then
+    case "$ALDC_URL" in
+        https://*) ;;
+        *) echo "❌ ALDC_URL は https:// で始まる必要があります: $ALDC_URL" >&2; exit 1 ;;
+    esac
+    case "$ALDC_URL" in *[[:space:]]*) echo "❌ ALDC_URL に空白は含められません: $ALDC_URL" >&2; exit 1 ;; esac
+    DOCKER_ENV_VARS="$DOCKER_ENV_VARS -e ALDC_URL=$ALDC_URL"
+fi
+if [ -n "${SETUP_GIT_EMAIL_DOMAIN:-}" ]; then
+    case "$SETUP_GIT_EMAIL_DOMAIN" in
+        *[!A-Za-z0-9.-]*|"") echo "❌ SETUP_GIT_EMAIL_DOMAIN に使用できない文字が含まれています: $SETUP_GIT_EMAIL_DOMAIN" >&2; exit 1 ;;
+    esac
+    DOCKER_ENV_VARS="$DOCKER_ENV_VARS -e SETUP_GIT_EMAIL_DOMAIN=$SETUP_GIT_EMAIL_DOMAIN"
+fi
+
 # 文書タイプ固有の環境変数を渡す
 case "$DETECTED_DOC_TYPE" in
     latex)

--- a/create-repo/templates/auto_assign_myteams.yml
+++ b/create-repo/templates/auto_assign_myteams.yml
@@ -9,7 +9,7 @@ addAssignees: true
 
 # Reviewerに設定するメンバを追加します。
 reviewers:
-  - toshi0806
+  - __AUTO_ASSIGN_REVIEWER__
 
 # Reviewersに追加するメンバ数を指定できます。
 # 追加メンバより設定数が少ない場合、ランダムで追加されます。
@@ -18,7 +18,7 @@ numberOfReviewers: 0
 
 # Assigneesに設定するメンバを追加します。
 assignees:
-  - toshi0806
+  - __AUTO_ASSIGN_REVIEWER__
 
 # Assigneesに追加するメンバ数を指定できます。
 # 追加メンバより設定数が少ない場合、ランダムで追加されます。

--- a/docs/CLAUDE-DEVELOPMENT.md
+++ b/docs/CLAUDE-DEVELOPMENT.md
@@ -55,6 +55,14 @@ variables (defaults preserve smkwlab behavior):
 | `TOOLS_REPO_OWNER` | `$DEFAULT_ORG` | Owner of the `thesis-management-tools` repo cloned internally. Distinct from `TARGET_ORG` (which may be a personal account). |
 | `TOOLS_REPO_NAME` | `thesis-management-tools` | Repo name cloned internally and forwarded to the container for registry integration. |
 | `TOOLS_CLONE_URL` | `https://github.com/<owner>/<repo>.git` | Full override of the clone URL (e.g. GitHub Enterprise / mirror). Must start with `https://` or `git@`. When set alone, also set `TOOLS_REPO_OWNER`/`TOOLS_REPO_NAME` so the usage/releases URLs in help text match the actual clone source. |
+| `TEMPLATE_REPO` | per doc type | Source template repo. `thesis`/`ise`/`wr` default to `<org>/…`; `latex`/`poster` default to `smkwlab/…` (shared templates used by individual accounts too). Set to `<org>/<template>` to use your own. |
+| `AUTO_ASSIGN_REVIEWER` | `toshi0806` | GitHub login inserted as the reviewer/assignee in the auto-assign config injected into organization-member repos. Set to a member of your org, or auto-assign will not work. |
+| `ALDC_URL` | `https://raw.githubusercontent.com/smkwlab/aldc/main/aldc` | Source of the aldc LaTeX-devcontainer installer fetched during setup. Must start with `https://`. |
+| `SETUP_GIT_EMAIL_DOMAIN` | `smkwlab.github.io` | Domain for the `setup-*@…` commit-author email used by the container. |
+
+These container-side overrides (`TEMPLATE_REPO`, `AUTO_ASSIGN_REVIEWER`,
+`ALDC_URL`, `SETUP_GIT_EMAIL_DOMAIN`) are forwarded from `setup.sh` into the
+Docker container only when set, each validated against a safe character set.
 
 `TOOLS_REPO_OWNER` / `TOOLS_REPO_NAME` are validated against a safe character
 set (character class only) before being embedded in the clone URL; GitHub's


### PR DESCRIPTION
## 概要

`setup.sh` 本体（#498 で対応済み）以外に残っていた create-repo の smkwlab/個人アカウント固定を解消し、コンテナ側の作成スクリプトを他 org へ展開可能にする。既定値はすべて現行の smkwlab / toshi0806 のままで**挙動不変**。各値に env override を追加し、setup.sh が検証付きでコンテナへ転送する。

Resolves #499

## 変更内容

- **main-latex.sh / main-poster.sh**: テンプレートを `${TEMPLATE_REPO:-smkwlab/latex-template}` から取得。latex/poster は個人ユーザー（ORGANIZATION=個人アカウント）も引く共有テンプレのため、org 追従にはせず既定を smkwlab 固定のまま override 可能にした（理由をコメント明記）
- **auto-assign（最重要）**: reviewer/assignee を `AUTO_ASSIGN_REVIEWER`（既定 toshi0806）に。`auto_assign_myteams.yml` をプレースホルダ `__AUTO_ASSIGN_REVIEWER__` 化し、injection 時に sed 置換。**他 org では toshi0806 が存在せず auto-assign が黙って機能しない問題を解消**
- **aldc URL**: `ALDC_URL`（既定 smkwlab 公開 aldc、https:// 限定）で上書き可能に
- **git author email**: ドメインを `SETUP_GIT_EMAIL_DOMAIN`（既定 smkwlab.github.io）で上書き可能に
- **setup.sh**: 上記 4 変数をコンテナへ検証付きで転送（現状これらは未転送で、主経路から使えなかった）
- **docs**: 新 env 変数を Development guide に追記

## 検証

- `bash -n`: setup.sh / common-lib.sh / main-latex.sh / main-poster.sh すべて OK
- auto_assign の sed 置換テスト: 既定（toshi0806）で現行と同一出力・プレースホルダ残留 0、カスタム reviewer 正常置換、不正値（`a/b` `a b` 空 `x&y`）を拒否
- 既定値解決テスト: TEMPLATE_REPO / ALDC_URL / email ドメインが未設定時に現行 smkwlab 値へ解決
- setup.sh 転送バリデーション: TEMPLATE_REPO（owner/repo 受理・空白/`;` 拒否）、ALDC_URL（https 受理・http/ext::/空白 拒否）、SETUP_GIT_EMAIL_DOMAIN（ドメイン受理・空白/`/` 拒否）

## 補足

- テンプレの placeholder 化は消費者が common-lib.sh の 1 箇所のみであることを確認済み（他に literal 依存なし）
- git author email ドメインは Issue で優先度低とされていたが、cheap なため同時対応

関連: #498（merged）, latex-ecosystem #105