### PR TITLE
docs: replace non-existent script names with unified setup.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,12 +33,12 @@ GitHub を使った効率的な論文指導をサポートします。
 
 #### 週間報告用
 ```bash
-/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/smkwlab/student-repo-management/main/create-repo/setup-wr.sh)"
+/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/smkwlab/student-repo-management/main/create-repo/setup.sh)" bash wr
 ```
 
 #### 汎用LaTeX文書用（研究ノート、レポート等）
 ```bash
-/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/smkwlab/student-repo-management/main/create-repo/setup-latex.sh)"
+/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/smkwlab/student-repo-management/main/create-repo/setup.sh)" bash latex
 ```
 
 **実行手順:**
@@ -127,7 +127,7 @@ INDIVIDUAL_MODE=true /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.co
   - クロスプラットフォーム対応
   - ブラウザ認証統合
 
-- **[main.sh](create-repo/main.sh)**: Docker内実行メインスクリプト
+- **main-*.sh**（`main-thesis.sh` / `main-wr.sh` / `main-latex.sh` / `main-ise.sh` / `main-poster.sh`）: 文書タイプ別の Docker 内実行メインスクリプト
   - GitHub認証・リポジトリ作成
   - LaTeX環境自動セットアップ
   - ブランチ構造初期化

--- a/create-repo/README.md
+++ b/create-repo/README.md
@@ -17,7 +17,7 @@
 **情報科学演習I・II用のレポートリポジトリを作成する場合：**
 
 ```bash
-STUDENT_ID=k21rs001 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/smkwlab/student-repo-management/main/create-repo/setup-ise.sh)"
+STUDENT_ID=k21rs001 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/smkwlab/student-repo-management/main/create-repo/setup.sh)" bash ise
 ```
 
 ※ `k21rs001` の部分を自分の学籍番号に変更してください。
@@ -27,7 +27,7 @@ STUDENT_ID=k21rs001 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com
 **研究週報用のリポジトリを作成する場合：**
 
 ```bash
-STUDENT_ID=k21rs001 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/smkwlab/student-repo-management/main/create-repo/setup-wr.sh)"
+STUDENT_ID=k21rs001 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/smkwlab/student-repo-management/main/create-repo/setup.sh)" bash wr
 ```
 
 **前提条件:**

--- a/create-repo/setup.sh
+++ b/create-repo/setup.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # 統合リポジトリ作成スクリプト (Universal Setup Script)
-# 使用例: /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/smkwlab/student-repo-management/main/create-repo/setup-universal.sh)"
+# 使用例: /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/smkwlab/student-repo-management/main/create-repo/setup.sh)" bash thesis
 
 set -e
 

--- a/docs/CLAUDE-DEVELOPMENT.md
+++ b/docs/CLAUDE-DEVELOPMENT.md
@@ -108,12 +108,18 @@ Sophisticated GitHub Actions-based supervision:
 ### Repository Structure
 ```
 create-repo/
-├── Dockerfile                  # Main thesis repository creation
-├── Dockerfile-wr               # Weekly report repository creation
-├── main.sh                     # Thesis creation script
+├── setup.sh                    # Universal entry point (all document types)
+├── main-thesis.sh              # Thesis creation script
 ├── main-wr.sh                  # Weekly report creation script
-├── setup.sh                    # Public entry point for thesis
-├── setup-wr.sh                 # Public entry point for weekly reports
+├── main-latex.sh               # General LaTeX creation script
+├── main-ise.sh                 # ISE report creation script
+├── main-poster.sh              # Poster creation script
+├── common-lib.sh               # Shared functions and utilities
+├── Dockerfile-thesis           # Docker image for thesis
+├── Dockerfile-wr               # Docker image for weekly reports
+├── Dockerfile-latex            # Docker image for general LaTeX
+├── Dockerfile-ise              # Docker image for ISE reports
+├── Dockerfile-poster           # Docker image for poster
 └── README.md                   # Usage instructions
 
 scripts/

--- a/docs/CLAUDE-EXAMPLES.md
+++ b/docs/CLAUDE-EXAMPLES.md
@@ -13,7 +13,7 @@ This document provides detailed command examples and usage samples for student-r
 STUDENT_ID=k21rs001 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/smkwlab/student-repo-management/main/create-repo/setup.sh)"
 
 # For weekly reports
-STUDENT_ID=k21rs001 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/smkwlab/student-repo-management/main/create-repo/setup-wr.sh)"
+STUDENT_ID=k21rs001 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/smkwlab/student-repo-management/main/create-repo/setup.sh)" bash wr
 ```
 
 ### Universal Setup Script with Document Types

--- a/scripts/process-pending-issues.sh
+++ b/scripts/process-pending-issues.sh
@@ -579,7 +579,7 @@ extract_issue_info() {
     # 主因だったため廃止（issue #471）。卒論・修論は命名規約 *-sotsuron /
     # *-master（防御的別名 *-thesis）で必ずパターン3までに判定される
     # パターン5: その他のパターンは latex と推測
-    # setup-latex.sh は様々な命名規則のリポジトリに対応するため、
+    # latex タイプは様々な命名規則のリポジトリに対応するため、
     # 明示的なタイプ情報がない場合は LaTeX リポジトリとして扱う
     elif [[ "$CURRENT_REPO_NAME" =~ -[a-zA-Z0-9_-]+$ && ! "$CURRENT_REPO_NAME" == *"-latex" ]]; then
         CURRENT_REPO_TYPE="latex"


### PR DESCRIPTION
## 概要

`create-repo/` の実体は `setup.sh` のみ（`setup-*.sh` は存在しない）にもかかわらず、ドキュメント・usage・構成図・コメントに universal 統一以前の**実在しないスクリプト名**が残っており、該当 curl コマンドをコピー実行すると 404 になっていました。これらを現行の `setup.sh` + 位置引数形式に統一します。

## 変更内容

**実行 curl URL（404 の実害）→ `setup.sh` + 位置引数（`bash wr` / `latex` / `ise`）**
- `README.md`（`setup-wr.sh` / `setup-latex.sh`）
- `create-repo/README.md`（`setup-ise.sh` / `setup-wr.sh`）
- `docs/CLAUDE-EXAMPLES.md`（`setup-wr.sh`）
- `create-repo/setup.sh:3` usage 文言（`setup-universal.sh`）

**同種の実在しないスクリプト名 → 実態へ**
- `docs/CLAUDE-DEVELOPMENT.md` の Repository Structure 構成図：単数 `main.sh` / `setup-wr.sh` / `Dockerfile`（単数）→ 実在する `main-*.sh` 群・`setup.sh`・`Dockerfile-*` 群に更新
- `README.md` の `create-repo/main.sh` リンク → 文書タイプ別 `main-*.sh` の記述に
- `scripts/process-pending-issues.sh` のコメント内 `setup-latex.sh` → 「latex タイプ」に（動作影響なし）

## スコープ

`#504`（リポジトリ改名）で URL のリポジトリ名部分は追随済み。本 PR はそれとは独立した、スクリプト名の誤記の修正です。`doc-update-proposal.md`（universal 統一を提案した歴史資料）は対象外。

## 検証

`git grep` で `setup-{wr,latex,ise,universal,thesis}.sh` の残存がゼロであることを確認。

Resolves #505