### PR TITLE
fix: retry pushes in setup scripts to avoid dropped branches

### DIFF
--- a/create-repo/common-lib.sh
+++ b/create-repo/common-lib.sh
@@ -444,6 +444,31 @@ clone_repository() {
 # Note: git add . を使用するのは、セットアップ時に新規作成されるファイル
 # （.devcontainer/, .github/ 等）も含めてステージングする必要があるため。
 # 呼び出し元で git add -u を使用する場合は、事前にステージングを行うこと。
+# git push をリトライする共通ヘルパー（Issue #511）。
+# 一斉作成時の一過性エラー（push 競合・API レート制限・ネットワーク瞬断）を吸収し、
+# ブランチの取りこぼしを防ぐ。線形バックオフ（1 秒, 2 秒, ...）で再試行する。
+# Args:
+#   $1: branch       - push するブランチ名
+#   $2: max_attempts - 最大試行回数（既定 3）
+push_with_retry() {
+    local branch="$1"
+    local max_attempts="${2:-3}"
+    local attempt=1
+
+    while true; do
+        if git push origin "$branch" >/dev/null 2>&1; then
+            return 0
+        fi
+        if [ "$attempt" -ge "$max_attempts" ]; then
+            log_error "push に ${max_attempts} 回失敗しました（${branch}）"
+            return 1
+        fi
+        log_warn "push 失敗（${branch}, ${attempt}/${max_attempts} 回目）。${attempt} 秒後に再試行します"
+        sleep "$attempt"
+        attempt=$((attempt + 1))
+    done
+}
+
 commit_and_push() {
     local commit_message="$1"
     local branch="${2:-main}"
@@ -452,7 +477,7 @@ commit_and_push() {
     git add . >/dev/null 2>&1
     git commit -m "$commit_message" >/dev/null 2>&1
     
-    if git push origin "$branch" >/dev/null 2>&1; then
+    if push_with_retry "$branch"; then
         log_info "変更をプッシュしました"
         return 0
     else

--- a/create-repo/common-lib.sh
+++ b/create-repo/common-lib.sh
@@ -454,16 +454,21 @@ push_with_retry() {
     local branch="$1"
     local max_attempts="${2:-3}"
     local attempt=1
+    local err
 
     while true; do
-        if git push origin "$branch" >/dev/null 2>&1; then
+        # stderr を捨てずに捕捉し、失敗時の原因（rejected / permission / protected
+        # branch など）をログに残す。永続的エラーの事後調査を可能にする（Issue #511）。
+        if err=$(git push origin "$branch" 2>&1); then
             return 0
         fi
         if [ "$attempt" -ge "$max_attempts" ]; then
             log_error "push に ${max_attempts} 回失敗しました（${branch}）"
+            log_error "  最後のエラー: ${err}"
             return 1
         fi
         log_warn "push 失敗（${branch}, ${attempt}/${max_attempts} 回目）。${attempt} 秒後に再試行します"
+        log_warn "  エラー詳細: ${err}"
         sleep "$attempt"
         attempt=$((attempt + 1))
     done

--- a/create-repo/main-ise.sh
+++ b/create-repo/main-ise.sh
@@ -150,7 +150,7 @@ git add .github/ 2>/dev/null || true
 git add .devcontainer/ 2>/dev/null || true
 git commit -m "Initial setup for ISE Report #${ISE_REPORT_NUM}" >/dev/null 2>&1 || true
 
-if git push origin main >/dev/null 2>&1; then
+if push_with_retry main; then
     log_info "main ブランチセットアップ完了"
 else
     die "main ブランチのプッシュに失敗しました"

--- a/create-repo/main-thesis.sh
+++ b/create-repo/main-thesis.sh
@@ -76,7 +76,7 @@ git add .github/ 2>/dev/null || true
 git add .devcontainer/ 2>/dev/null || true
 git commit -m "Initial setup for ${THESIS_TYPE}" >/dev/null 2>&1 || true
 
-if git push origin main >/dev/null 2>&1; then
+if push_with_retry main; then
     log_info "main ブランチセットアップ完了"
 else
     die "main ブランチのプッシュに失敗しました"


### PR DESCRIPTION
## 概要

リポジトリ作成スクリプトの `git push` がリトライを行わず、一斉作成時の一過性エラー（push 競合・API レート制限・ネットワーク瞬断）で処理が中断し、ブランチの取りこぼしが起きていました。共通ヘルパーでリトライを入れて吸収します。

## 実例

`k24rs062-ise-report1`（2026-07-08 に一斉作成された `k24rs*-ise-report1` 10件のうち1件）で **0th-draft が欠落**。main の push は成功したが直後の `git push origin 0th-draft` が失敗し、`main-ise.sh` が `|| exit 1` で中断していました（他9件は正常）。手動で復旧済み。

## 変更内容

- `common-lib.sh` に `push_with_retry <branch> [attempts]` を追加（線形バックオフ 1s→2s、既定3回）
- `commit_and_push` の push をそれに置換 → **thesis / ise / wr / latex / poster 全文書タイプが恩恵**
- `main-thesis.sh:79` / `main-ise.sh:153` の直接 `git push origin main` もそれに置換

これで `git push origin` を直接叩く箇所は `push_with_retry` 内の1つだけになりました。

## 検証

- `bash -n` で3ファイルとも構文 OK
- `grep` で直接 push の残存がヘルパー内1箇所のみであることを確認

Resolves #511