### PR TITLE
fix: pin auto-assign-action to @v2 to stop dependabot noise in student repos

### DIFF
--- a/create-repo/templates/autoassignees.yml
+++ b/create-repo/templates/autoassignees.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Assignees and Reviewers to PR
-        uses: kentaro-m/auto-assign-action@v2.0.0
+        uses: kentaro-m/auto-assign-action@v2
         with:
           repo-token: "${{ secrets.GITHUB_TOKEN }}"
           configuration-path: ".github/auto_assign_myteams.yml"


### PR DESCRIPTION
## 問題

各学生リポジトリに注入される `create-repo/templates/autoassignees.yml` が `kentaro-m/auto-assign-action@v2.0.0`(**完全固定**)を使っていたため、dependabot が全生成リポジトリに patch 更新 PR「Bump kentaro-m/auto-assign-action from 2.0.0 to 2.0.2」を作成していました。これはレポート執筆と無関係のノイズで、`thesis-monitor` の `--pending-reviews` 件数も水増ししていました(ISE 10 リポジトリで各1件)。

## 対応

`@v2.0.0`(完全固定)→ **`@v2`(移動タグ)** に変更。直下の `technote-space/assign-author@v1` と同じくメジャータグ固定とし、dependabot がこの action の patch/minor 更新 PR を出さないようにします。

## スコープ

- 本 PR は**今後の新規リポジトリ**への抑制です
- **既存 ISE リポジトリの dependabot PR 10件は別途マージ済み**(auto-assign-action 2.0.0→2.0.2 の安全な patch 更新)

## 補足

`dependabot.yml`(github-actions monthly)自体は残すため、メジャー更新(v3 等)が出た際は引き続き PR が作られます(頻度は大幅減)。