### PR TITLE
fix: strip dependabot.yml from generated student repos

### DIFF
--- a/create-repo/common-lib.sh
+++ b/create-repo/common-lib.sh
@@ -632,6 +632,10 @@ cleanup_template_files() {
     rm -f CLAUDE.md 2>/dev/null || true
     rm -rf docs/ 2>/dev/null || true
     find . -name '*-aldc' -exec rm -rf {} + 2>/dev/null || true
+    # 学生リポジトリでは Actions の自動更新は不要（最新化はテンプレート側の dependabot
+    # で管理）。誤マージ防止 CI（prevent-draft-merge）や review 必須保護と dependabot PR
+    # が干渉して溜まるため、生成時に削除する（#514）。
+    rm -f .github/dependabot.yml 2>/dev/null || true
     return 0
 }
 


### PR DESCRIPTION
## 問題

全テンプレート（sotsuron / wr / ise-report / latex / poster）の `dependabot.yml`(github-actions monthly)が生成された学生リポジトリにコピーされ、dependabot が各学生リポジトリに Actions 更新 PR を出します。これらが学生リポジトリの **`prevent-draft-merge`(誤マージ防止 CI)** や **review 必須のブランチ保護**と干渉し、マージできず溜まって教員の手動介入が必要になっています(#513 で ISE の実例に対処)。

学生リポジトリに Actions の自動更新は不要で、action の最新化はテンプレート側の dependabot で管理すれば十分です。

## 対応

`common-lib.sh` の `cleanup_template_files`(全 main-*.sh から呼ばれ、既に CLAUDE.md / docs/ / *-aldc を削除している)に **`.github/dependabot.yml` の削除を追加**。全 doc type 横断で、生成時に学生リポジトリから dependabot.yml が消えます。

- **テンプレート自身の `dependabot.yml` は維持**(action 最新化のため)
- `bash -n` 構文チェック済み

## スコープ

- 本 PR は**今後の新規リポジトリ**の根絶
- **既存の学生リポジトリからの一括削除は別作業**（Phase 2 として続けて実施予定）

Resolves #514