### PR TITLE
fix(create-repo): honor TEMPLATE_REPO override for wr/ise document types (#517)

### DIFF
--- a/create-repo/main.sh
+++ b/create-repo/main.sh
@@ -93,12 +93,13 @@ ORGANIZATION=$(determine_organization)
 
 # テンプレートリポジトリの決定。全タイプで TEMPLATE_REPO による上書きに対応する
 # （setup.sh はタイプ非依存で TEMPLATE_REPO をコンテナへ転送する）。既定値のみ
-# タイプごとにポリシーが異なる:
-# - thesis / wr / ise: org 追従（${ORGANIZATION}/<template>）。他 org で独自テンプレを
-#   使う場合は TEMPLATE_REPO で上書きする。
-# - latex / poster: 個人ユーザー（ORGANIZATION=個人アカウント）も利用する共有
-#   テンプレのため、org 追従にはせず既定を smkwlab に固定する。他 org で独自
-#   テンプレを使う場合は TEMPLATE_REPO で上書きする。
+# タイプごとにポリシーが異なり、「既定値の由来」で 2 グループに分かれる（この分類は
+# 下の case の並び順とは独立。case はファイル全体で統一している標準順
+# thesis→wr→latex→ise→poster を維持しているため、latex はグループ間に挟まって見える）:
+# - org 追従（${ORGANIZATION}/<template>） … thesis / wr / ise
+# - smkwlab 固定 … latex / poster（個人ユーザー = ORGANIZATION が個人アカウントでも
+#   利用する共有テンプレのため、org 追従にせず既定を smkwlab に固定する）
+# いずれのグループも、他 org で独自テンプレを使う場合は TEMPLATE_REPO で上書きする。
 # 注意: TEMPLATE_REPO 未設定時の既定は従来と同一（挙動不変）。以前は wr / ise のみ
 # TEMPLATE_REPO を無視していた（silent ignore）が、Issue #517 で全タイプ上書き可に統一。
 case "$DOC_TYPE" in

--- a/create-repo/main.sh
+++ b/create-repo/main.sh
@@ -91,17 +91,21 @@ init_script_common "$SCRIPT_TITLE" "$SCRIPT_EMOJI"
 # ================================
 ORGANIZATION=$(determine_organization)
 
-# テンプレートリポジトリの決定。タイプごとにポリシーが異なる:
-# - thesis: org 追従。他 org で独自テンプレを使う場合は TEMPLATE_REPO で上書き
-# - wr / ise: org 追従固定（TEMPLATE_REPO 非対応。既存挙動の温存 — Issue #517）
+# テンプレートリポジトリの決定。全タイプで TEMPLATE_REPO による上書きに対応する
+# （setup.sh はタイプ非依存で TEMPLATE_REPO をコンテナへ転送する）。既定値のみ
+# タイプごとにポリシーが異なる:
+# - thesis / wr / ise: org 追従（${ORGANIZATION}/<template>）。他 org で独自テンプレを
+#   使う場合は TEMPLATE_REPO で上書きする。
 # - latex / poster: 個人ユーザー（ORGANIZATION=個人アカウント）も利用する共有
 #   テンプレのため、org 追従にはせず既定を smkwlab に固定する。他 org で独自
 #   テンプレを使う場合は TEMPLATE_REPO で上書きする。
+# 注意: TEMPLATE_REPO 未設定時の既定は従来と同一（挙動不変）。以前は wr / ise のみ
+# TEMPLATE_REPO を無視していた（silent ignore）が、Issue #517 で全タイプ上書き可に統一。
 case "$DOC_TYPE" in
     thesis) TEMPLATE_REPOSITORY="${TEMPLATE_REPO:-${ORGANIZATION}/sotsuron-template}" ;;
-    wr)     TEMPLATE_REPOSITORY="${ORGANIZATION}/wr-template" ;;
+    wr)     TEMPLATE_REPOSITORY="${TEMPLATE_REPO:-${ORGANIZATION}/wr-template}" ;;
     latex)  TEMPLATE_REPOSITORY="${TEMPLATE_REPO:-smkwlab/latex-template}" ;;
-    ise)    TEMPLATE_REPOSITORY="${ORGANIZATION}/ise-report-template" ;;
+    ise)    TEMPLATE_REPOSITORY="${TEMPLATE_REPO:-${ORGANIZATION}/ise-report-template}" ;;
     poster) TEMPLATE_REPOSITORY="${TEMPLATE_REPO:-smkwlab/poster-template}" ;;
 esac
 VISIBILITY="private"


### PR DESCRIPTION
## 概要

`DOC_TYPE=wr` / `ise` で `TEMPLATE_REPO` を指定しても**無警告で無視される** (silent ignore) 問題を修正する。main.sh のテンプレート決定 case で wr/ise を `${TEMPLATE_REPO:-${ORGANIZATION}/<template>}` に統一し、全タイプで `TEMPLATE_REPO` 上書きに対応させる。

Resolves #517

## 背景

- setup.sh は `TEMPLATE_REPO` を**タイプ非依存**でコンテナへ転送している (DOC_TYPE 分岐の外)。
- しかし旧 main-wr.sh / main-ise.sh は `${ORGANIZATION}/<template>` 固定で `TEMPLATE_REPO` を参照せず、#516 統合後の main.sh もその挙動を逐語温存していた。
- 一方 docs/CLAUDE-DEVELOPMENT.md は `TEMPLATE_REPO` を**全タイプで上書き可**と記載しており、**文書と実装が矛盾**していた。

本 PR は実装を文書に一致させる。#516 統合後のため、修正は main.sh のテンプレート決定 case **1 箇所**で済む。

## 変更内容

```diff
-    wr)     TEMPLATE_REPOSITORY="${ORGANIZATION}/wr-template" ;;
+    wr)     TEMPLATE_REPOSITORY="${TEMPLATE_REPO:-${ORGANIZATION}/wr-template}" ;;
-    ise)    TEMPLATE_REPOSITORY="${ORGANIZATION}/ise-report-template" ;;
+    ise)    TEMPLATE_REPOSITORY="${TEMPLATE_REPO:-${ORGANIZATION}/ise-report-template}" ;;
```

- policy コメントも「全タイプで上書き対応・既定のみタイプ別」に更新。
- setup.sh は変更不要 (既にタイプ非依存で転送)。docs も変更不要 (既に全タイプ上書き可と記載)。

## 挙動への影響

- **`TEMPLATE_REPO` 未設定時の既定は従来と完全に同一** (wr → `<org>/wr-template`、ise → `<org>/ise-report-template`)。既定挙動は不変。
- **設定時のみ**、wr/ise でも上書きが効くようになる (thesis/latex/poster と同じ挙動に統一)。
- 多 org 展開 (#105) の「fork 側でのテンプレ差し替え自由度」とも整合。

## 検証

- `bash -n create-repo/main.sh` OK
- case ロジックを全 5 タイプ × (未設定 / 設定) で評価し、未設定=従来と同一・設定=上書き有効を確認:

| DOC_TYPE | 未設定 (既定) | `TEMPLATE_REPO=myorg/custom` |
|---|---|---|
| thesis | `<org>/sotsuron-template` | `myorg/custom` |
| wr | `<org>/wr-template` | `myorg/custom` ✅新 |
| latex | `smkwlab/latex-template` | `myorg/custom` |
| ise | `<org>/ise-report-template` | `myorg/custom` ✅新 |
| poster | `smkwlab/poster-template` | `myorg/custom` |