### PR TITLE
perf(create-repo): drop vestigial nodejs/npm from unified image (#518)

### DIFF
--- a/create-repo/Dockerfile
+++ b/create-repo/Dockerfile
@@ -2,8 +2,8 @@ FROM alpine:3.24.1@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6ee
 
 # 必要なツールをインストール
 # 注: 旧構成では nodejs/npm も入れていたが、これは #180 当時に aldc を npm 経由で
-# インストールしていた名残。現在 aldc は curl+bash 実行に変わり、作成フロー
-# (main.sh / common-lib.sh) も aldc 本体も node を一切使わないため削除した（Issue #518）。
+# インストールしていた名残。現在 aldc は curl+bash 実行に変わり、作成スクリプト群
+# (setup.sh / main.sh / common-lib.sh) も aldc 本体も node を一切使わないため削除した（Issue #518）。
 RUN apk add --no-cache \
     git \
     curl \

--- a/create-repo/Dockerfile
+++ b/create-repo/Dockerfile
@@ -1,17 +1,16 @@
 FROM alpine:3.24.1@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b
 
 # 必要なツールをインストール
-# nodejs/npm は旧 Dockerfile-ise のみが持っていた追加パッケージ。統合にあたり
-# superset として常時インストールする（実際の要否調査は Issue #518）
+# 注: 旧構成では nodejs/npm も入れていたが、これは #180 当時に aldc を npm 経由で
+# インストールしていた名残。現在 aldc は curl+bash 実行に変わり、作成フロー
+# (main.sh / common-lib.sh) も aldc 本体も node を一切使わないため削除した（Issue #518）。
 RUN apk add --no-cache \
     git \
     curl \
     bash \
     ca-certificates \
     unzip \
-    jq \
-    nodejs \
-    npm
+    jq
 
 # GitHub CLI をインストール
 RUN ARCH=$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/') && \


### PR DESCRIPTION
## 概要

統合 Docker イメージから **nodejs / npm を削除**する。調査の結果、これらは #180 当時の npm 経由 aldc インストールの名残 (vestigial) で、現在はどの作成フローからも使われていないことが確定した。

Resolves #518

## 調査結論

| 調査対象 | node/npm 参照 |
|---|---|
| create-repo スクリプト (main.sh / common-lib.sh / setup.sh) | **ゼロ** |
| aldc 本体 (curl で取得し作成コンテナ内で実行される bash) | **ゼロ** |

- **git 履歴**: nodejs/npm は #180 (2e295d1) で追加。当時は aldc を `npm install -g @smkwlab/aldc@latest` でインストールしていたための依存。現在の `setup_latex_environment` は aldc を **curl + bash 実行**に変更済みで、npm 経路は消滅している。
- ise は `RUN_ALDC=false` で aldc すら実行しない (「ISE用に」という当時のコメントは不正確だった)。
- aldc は devcontainer ファイルを配置するだけで、node が要るのは**学生の devcontainer 起動時**であり作成コンテナ内ではない。

## 変更内容

```diff
 RUN apk add --no-cache \
     git \
     curl \
     bash \
     ca-certificates \
     unzip \
-    jq \
-    nodejs \
-    npm
+    jq
```

由来コメントも「#180 の npm-aldc の名残であり現在は不要」と実態に更新。

## 効果

- **イメージサイズ: 143MB → 66.2MB (約 77MB / 54% 削減)**。
- イメージは学生の実行のたびにビルド・削除されるため、`apk add` + ビルド時間の短縮 = **学生の待ち時間削減**に直結する。

## 検証

- node なしイメージの `docker build` 成功
- イメージ内に `node` / `npm` が**不在**であることを確認
- `DOC_TYPE` 未指定=`${DOC_TYPE:?}` 早期エラー / 不正値=case 再検証 die を確認
- 参照ゼロ (スクリプト+aldc で実証) かつ node ありイメージで #516 の full E2E (5 タイプ 6 シナリオ) を通過済みのため、**参照されないパッケージの削除は作成フローの実行時挙動を変え得ない**。したがって作成 E2E の再実行は不要と判断 (必要なら実施可)。