### PR TITLE
fix(create-repo): fix setup.sh env forwarding — drop dead vars, wire poster names (#519)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,7 +22,7 @@ STUDENT_ID=k21rs001 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com
 DOC_TYPE=thesis /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/smkwlab/student-repo-management/main/create-repo/setup.sh)"
 
 # Advanced configuration with environment variables
-DOCUMENT_NAME=research-note AUTHOR_NAME="Taro Yamada" STUDENT_ID=k21rs001 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/smkwlab/student-repo-management/main/create-repo/setup.sh)" bash latex
+DOCUMENT_NAME=research-note STUDENT_ID=k21rs001 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/smkwlab/student-repo-management/main/create-repo/setup.sh)" bash latex
 
 # Individual mode for personal LaTeX documents (no student ID required)
 INDIVIDUAL_MODE=true DOCUMENT_NAME=my-paper /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/smkwlab/student-repo-management/main/create-repo/setup.sh)" bash latex
@@ -109,7 +109,6 @@ Universal Setup Script uses `DOC_TYPE` environment variable to specify document 
 ```bash
 # LaTeX document configuration
 DOCUMENT_NAME=research-note    # Custom document name
-AUTHOR_NAME="Taro Yamada"      # Author name
 
 # Individual mode behavior (DOC_TYPE=latex only)
 INDIVIDUAL_MODE=true           # Skip student ID input, create in personal account
@@ -117,7 +116,6 @@ INDIVIDUAL_MODE=true           # Skip student ID input, create in personal accou
 # Note: Individual mode automatically disables Registry Manager integration
 
 # ISE report configuration
-ASSIGNMENT_TYPE=exercise       # Assignment type
 ISE_REPORT_NUM=1              # Report number (1 or 2)
 ```
 

--- a/create-repo/setup.sh
+++ b/create-repo/setup.sh
@@ -599,6 +599,9 @@ fi
 # 非対話にできるのは「INDIVIDUAL_MODE（confirm_creation が自動承認）」かつ「名前が env で
 # 指定済み（名前プロンプトが出ない）」の場合のみ。latex は DOCUMENT_NAME、poster は
 # POSTER_NAME か DOCUMENT_NAME があれば非対話にできる（Issue #519 で poster を追加）。
+# poster で DOCUMENT_NAME のみ指定の場合も非対話で問題ない: コンテナ側 read_poster_name は
+# POSTER_NAME 未設定時に DOCUMENT_NAME を poster 名として採用する（フォールバック）ため、
+# 名前プロンプトは出ない。両方指定時は POSTER_NAME が優先される（env 転送・採用とも同順）。
 # 注: set -e 下で `[ ... ] && VAR=...` は左辺 false で終了してしまうため if 構造で書く。
 DOCKER_OPTIONS="--rm"
 INTERACTIVE=true

--- a/create-repo/setup.sh
+++ b/create-repo/setup.sh
@@ -540,23 +540,43 @@ if [ -n "${SETUP_GIT_EMAIL_DOMAIN:-}" ]; then
     DOCKER_ENV_VARS="$DOCKER_ENV_VARS -e SETUP_GIT_EMAIL_DOMAIN=$SETUP_GIT_EMAIL_DOMAIN"
 fi
 
+# DOCUMENT_NAME / POSTER_NAME はコンテナ側 main.sh で ^[a-zA-Z0-9_-]+$ を要求する。
+# ここでも無引用展開（docker run $DOCKER_ENV_VARS）に載るため、同じ文字種のみ許可して
+# 単語分割・glob を防ぐ（他の転送変数と同じ流儀）。
+valid_doc_name() {
+    case "$1" in
+        *[!A-Za-z0-9_-]*) return 1 ;;
+        "") return 1 ;;
+        *) return 0 ;;
+    esac
+}
+
 # 文書タイプ固有の環境変数を渡す
+# 注: 旧構成では latex に AUTHOR_NAME、ise に ASSIGNMENT_TYPE も転送していたが、
+# どちらもコンテナ側スクリプトから参照されない死に変数だったため削除した（Issue #519）。
 case "$DETECTED_DOC_TYPE" in
     latex)
         # ドキュメント名が環境変数で指定されている場合は渡す
         if [ -n "$DOCUMENT_NAME" ]; then
+            valid_doc_name "$DOCUMENT_NAME" || { echo "❌ DOCUMENT_NAME に使用できない文字が含まれています: $DOCUMENT_NAME" >&2; exit 1; }
             DOCKER_ENV_VARS="$DOCKER_ENV_VARS -e DOCUMENT_NAME=$DOCUMENT_NAME"
         fi
-        # 作者名が環境変数で指定されている場合は渡す
-        if [ -n "$AUTHOR_NAME" ]; then
-            DOCKER_ENV_VARS="$DOCKER_ENV_VARS -e AUTHOR_NAME=$AUTHOR_NAME"
+        ;;
+    poster)
+        # poster は POSTER_NAME を優先し、無ければ DOCUMENT_NAME を使う（main.sh の
+        # read_poster_name と同じ優先順位）。旧 setup.sh は poster でどちらも転送せず、
+        # 常に対話入力になっていた（Issue #519）。
+        if [ -n "$POSTER_NAME" ]; then
+            valid_doc_name "$POSTER_NAME" || { echo "❌ POSTER_NAME に使用できない文字が含まれています: $POSTER_NAME" >&2; exit 1; }
+            DOCKER_ENV_VARS="$DOCKER_ENV_VARS -e POSTER_NAME=$POSTER_NAME"
+        fi
+        if [ -n "$DOCUMENT_NAME" ]; then
+            valid_doc_name "$DOCUMENT_NAME" || { echo "❌ DOCUMENT_NAME に使用できない文字が含まれています: $DOCUMENT_NAME" >&2; exit 1; }
+            DOCKER_ENV_VARS="$DOCKER_ENV_VARS -e DOCUMENT_NAME=$DOCUMENT_NAME"
         fi
         ;;
     ise)
         # ISE固有の環境変数処理
-        if [ -n "$ASSIGNMENT_TYPE" ]; then
-            DOCKER_ENV_VARS="$DOCKER_ENV_VARS -e ASSIGNMENT_TYPE=$ASSIGNMENT_TYPE"
-        fi
         if [ -n "$ISE_REPORT_NUM" ]; then
             DOCKER_ENV_VARS="$DOCKER_ENV_VARS -e ISE_REPORT_NUM=$ISE_REPORT_NUM"
         fi
@@ -575,13 +595,26 @@ if [[ -n "$MSYSTEM" ]] || [[ "$OSTYPE" == "msys" ]] || [[ -n "$MINGW_PREFIX" ]] 
     fi
 fi
 
-# 対話的入力が必要かどうかを判断
+# 対話的入力が必要かどうかを判断。
+# 非対話にできるのは「INDIVIDUAL_MODE（confirm_creation が自動承認）」かつ「名前が env で
+# 指定済み（名前プロンプトが出ない）」の場合のみ。latex は DOCUMENT_NAME、poster は
+# POSTER_NAME か DOCUMENT_NAME があれば非対話にできる（Issue #519 で poster を追加）。
+# 注: set -e 下で `[ ... ] && VAR=...` は左辺 false で終了してしまうため if 構造で書く。
 DOCKER_OPTIONS="--rm"
-if [ "$DOC_TYPE" = "latex" ] && [[ "$INDIVIDUAL_MODE" =~ ^(true|TRUE|1|yes|YES)$ ]] && [ -n "$DOCUMENT_NAME" ]; then
-    # INDIVIDUAL_MODEでDOCUMENT_NAMEが指定されている場合は非対話的モード
-    echo "📋 非対話的モードで実行（DOCUMENT_NAME: $DOCUMENT_NAME）"
+INTERACTIVE=true
+if [[ "$INDIVIDUAL_MODE" =~ ^(true|TRUE|1|yes|YES)$ ]]; then
+    case "$DOC_TYPE" in
+        latex)
+            if [ -n "$DOCUMENT_NAME" ]; then INTERACTIVE=false; fi
+            ;;
+        poster)
+            if [ -n "$POSTER_NAME" ] || [ -n "$DOCUMENT_NAME" ]; then INTERACTIVE=false; fi
+            ;;
+    esac
+fi
+if [ "$INTERACTIVE" = false ]; then
+    echo "📋 非対話的モードで実行（$DOC_TYPE）"
 else
-    # その他の場合は対話的モード
     DOCKER_OPTIONS="$DOCKER_OPTIONS -it"
 fi
 


### PR DESCRIPTION
## 概要

setup.sh の文書タイプ別環境変数転送の非対称を修正する。

Resolves #519

## 変更内容

### 1. 死に変数の削除

`AUTHOR_NAME` (latex) / `ASSIGNMENT_TYPE` (ise) は setup.sh がコンテナへ転送していたが、コンテナ側 main.sh / common-lib.sh から**一切参照されない死に変数**だった (grep でゼロ確認)。

- setup.sh: 両変数の転送コードを削除 (削除理由を由来コメントで明記)
- CLAUDE.md: 両変数の記載を削除 (文書と実装の乖離を解消)

### 2. poster の env 転送 + 非対話化

旧 setup.sh は poster で `POSTER_NAME` / `DOCUMENT_NAME` をどちらも転送せず、`setup.sh` 経由の poster は**常に対話入力**になっていた。また非対話モード判定も latex 限定だった。

- 文書タイプ固有 env case に **poster 分岐を新設**し、`POSTER_NAME` → `DOCUMENT_NAME` の順で転送 (main.sh の `read_poster_name` と同じ優先順位)
- 無引用展開 (`docker run $DOCKER_ENV_VARS`) に載るため、他の転送変数と同様に**文字種検証** (`valid_doc_name`、コンテナ側と同じ `^[a-zA-Z0-9_-]+$`) を付与し、単語分割・glob を防ぐ
- **非対話モード判定を poster にも拡張** (`INDIVIDUAL_MODE` + 名前指定時)。`set -e` 下で `[ ... ] && VAR=...` が左辺 false で終了する落とし穴を避けるため `if` 構造に書き換え

## 挙動変化

- **poster**: `setup.sh` 経由で `INDIVIDUAL_MODE=true POSTER_NAME=... (または DOCUMENT_NAME=...)` を指定すると**非対話実行できる**ようになる (従来は常に対話)。
- **latex / thesis / wr / ise**: 挙動不変。latex の `DOCUMENT_NAME` 転送には文字種検証が加わったが、正常値では挙動同一 (不正値は従来の不明瞭な docker エラーではなく明示エラーで停止)。
- 死に変数の削除は参照ゼロのため挙動中立。

## 検証

- `bash -n create-repo/setup.sh` OK
- `AUTHOR_NAME` / `ASSIGNMENT_TYPE` の転送コードが残っていないこと (説明コメントのみ) を確認
- 非対話判定ロジックを抽出評価: poster (INDIVIDUAL_MODE+名前=非対話 / 名前なし=対話 / org モード=対話)、latex 従来どおり、thesis/wr/ise は常に対話
- env case を抽出評価: poster が `POSTER_NAME`/`DOCUMENT_NAME` を正しく転送、不正文字 (空白・`;`) は拒否
- コンテナ側の poster フロー (`-e POSTER_NAME` 受領) は #516 の E2E で実証済み。本 PR は setup.sh 側の転送を追加するもの