### PR TITLE
fix(create-repo): use JST for ISE semester detection and fix SC2155 (#520)

### DIFF
--- a/create-repo/main.sh
+++ b/create-repo/main.sh
@@ -223,6 +223,9 @@ determine_ise_report_number() {
     # SC2155 回避のため宣言と代入を分離する（他の gh api 呼び出しと同じ流儀）
     local current_month
     current_month=$(TZ='JST-9' date +%m)
+    # date 失敗で空になると後段の `(( 10#$current_month ... ))` が算術構文エラーになるため、
+    # 空でないことを保証する（現実にはまず失敗しないが防御的に）
+    [ -n "$current_month" ] || die "学期判定の日付取得に失敗しました"
     local preferred_num fallback_num
 
     # 10# でゼロ埋め月（08/09）の 8 進誤解釈を防ぐ

--- a/create-repo/main.sh
+++ b/create-repo/main.sh
@@ -220,7 +220,9 @@ determine_ise_report_number() {
     fi
 
     # 学期判定（日本の学期基準のため JST。busybox は tzdata 無しでも JST-9 を解釈する）
-    local current_month=$(TZ='JST-9' date +%m)
+    # SC2155 回避のため宣言と代入を分離する（他の gh api 呼び出しと同じ流儀）
+    local current_month
+    current_month=$(TZ='JST-9' date +%m)
     local preferred_num fallback_num
 
     # 10# でゼロ埋め月（08/09）の 8 進誤解釈を防ぐ

--- a/create-repo/main.sh
+++ b/create-repo/main.sh
@@ -179,12 +179,15 @@ read_poster_name() {
     fi
 }
 
-# --- ise: ISE レポート番号の決定とリポジトリ存在チェック（日時ベース、旧 main-ise.sh） ---
-# 注意: `local api_result=$(gh api ...)` 直後の `local api_status=$?` は local の
-# 終了コード（常に 0）を拾うため、「GitHub APIへのアクセスに問題」分岐は実際には
-# 到達しない既知の問題がある（SC2155、Issue #520）。挙動同値のため逐語温存して
-# おり、shellcheck 等による機械的な修正をここで行わないこと（修正するとレート
-# 制限・一時エラー時の挙動が変わる。対応は #520 で行う）。
+# --- ise: ISE レポート番号の決定とリポジトリ存在チェック（日時ベース） ---
+# 実装メモ（Issue #520 で修正）:
+# - 学期判定は日本の学期基準のため JST で行う（`TZ='JST-9'`）。Alpine busybox の date は
+#   tzdata 無しでも POSIX offset 形式 `JST-9`（UTC+9・DST なし）を解釈できる。
+# - `date +%m` はゼロ埋め（08/09）で、算術文脈 `(( ))` では 8 進数と解釈されエラーに
+#   なるため、比較は `10#` で 10 進を強制する。
+# - `local var=$(cmd)` は local 自体の終了コード（常に 0）で `$?` を潰す（SC2155）。
+#   API エラー分岐を機能させるため、宣言と代入を分離して `$?` が gh の終了コードを
+#   拾うようにしている。
 determine_ise_report_number() {
     local student_id="$1"
     local report_num
@@ -193,7 +196,8 @@ determine_ise_report_number() {
     if [ -n "$ISE_REPORT_NUM" ] && [ "$ISE_REPORT_NUM" != "auto" ]; then
         if [ "$ISE_REPORT_NUM" = "1" ] || [ "$ISE_REPORT_NUM" = "2" ]; then
             local target_repo="${ORGANIZATION}/${student_id}-ise-report${ISE_REPORT_NUM}"
-            local api_result=$(gh api "repos/${target_repo}" --jq .name 2>&1)
+            local api_result
+            api_result=$(gh api "repos/${target_repo}" --jq .name 2>&1)
             local api_status=$?
 
             if [ $api_status -eq 0 ]; then
@@ -215,11 +219,12 @@ determine_ise_report_number() {
         fi
     fi
 
-    # 学期判定
-    local current_month=$(date +%m)
+    # 学期判定（日本の学期基準のため JST。busybox は tzdata 無しでも JST-9 を解釈する）
+    local current_month=$(TZ='JST-9' date +%m)
     local preferred_num fallback_num
 
-    if (( current_month >= 4 && current_month <= 9 )); then
+    # 10# でゼロ埋め月（08/09）の 8 進誤解釈を防ぐ
+    if (( 10#$current_month >= 4 && 10#$current_month <= 9 )); then
         preferred_num=1
         fallback_num=2
         log_debug "前期期間 (${current_month}月): ise-report1 を優先"
@@ -231,7 +236,8 @@ determine_ise_report_number() {
 
     # 優先リポジトリをチェック
     local preferred_repo="${ORGANIZATION}/${student_id}-ise-report${preferred_num}"
-    local api_result=$(gh api "repos/${preferred_repo}" --jq .name 2>&1)
+    local api_result
+    api_result=$(gh api "repos/${preferred_repo}" --jq .name 2>&1)
     local api_status=$?
 
     if [ $api_status -ne 0 ]; then
@@ -249,7 +255,8 @@ determine_ise_report_number() {
     else
         # フォールバックをチェック
         local fallback_repo="${ORGANIZATION}/${student_id}-ise-report${fallback_num}"
-        local fallback_result=$(gh api "repos/${fallback_repo}" --jq .name 2>&1)
+        local fallback_result
+        fallback_result=$(gh api "repos/${fallback_repo}" --jq .name 2>&1)
         local fallback_status=$?
 
         if [ $fallback_status -ne 0 ]; then


### PR DESCRIPTION
## 概要

main.sh の `determine_ise_report_number`(ISE レポート番号の学期ベース判定)にある 3 つの不具合を修正する。

Resolves #520

## 修正内容

### 1. UTC 学期判定 → JST

学期判定 (4〜9 月 = 前期 → report1 優先) を `date +%m` で行っていたが、Alpine コンテナの既定 TZ が **UTC** のため、月境界の 0:00〜8:59 JST に実行すると前月扱いになり前期/後期がずれていた。

- `date +%m` → **`TZ='JST-9' date +%m`**
- Alpine busybox の `date` は **tzdata 無しでも POSIX offset 形式 `JST-9`(UTC+9)を解釈**できる (実機確認済み: イメージ内で UTC 11:38 → JST 20:38)。JST は DST が無いため固定オフセットで正確。#518 のスリム化を維持 (tzdata 追加不要)。

### 2. ゼロ埋め月の 8 進誤解釈 (調査中に発見した追加バグ)

`(( current_month >= 4 && current_month <= 9 ))` は `date +%m` のゼロ埋め月 `08` / `09` を bash が **8 進数と解釈してエラー**になり、`(( ))` が失敗して else 分岐へ落ちていた。結果、**8 月・9 月が誤って後期 (report2) 判定**される (UTC 境界の朝だけでなく月まるごと + stderr にエラー出力)。

- 比較を **`10#$current_month`** で 10 進強制して解消。

### 3. SC2155 (3 箇所)

`local api_result=$(gh api ...)` 直後の `local api_status=$?` は `local` 自身の終了コード (常に 0) を拾うため、非 404 の API エラーを検出する「API 問題 → exit 1」分岐が**到達不能**だった。

- `local` 宣言と代入を分離し、`$?` が gh の終了コードを拾うよう修正 (3 箇所: 手動指定 / 優先チェック / フォールバックチェック)。

## 挙動への影響

- **学期判定**: 8/9 月が正しく前期になり、月境界の JST ずれも解消。
- **API エラー処理**: 通常の 404 (リポジトリ非存在) / 成功系の挙動は**不変** (文字列一致で偶然正しく動作していた経路はそのまま)。**変わるのは非 404 エラー時のみ**で、従来は「非存在扱いで続行」していたレート制限・一時エラー・500 等が、意図どおり「API 問題 → exit 1」で停止するようになる (安全側)。

## 検証

- `bash -n create-repo/main.sh` OK
- 全 12 ヶ月の学期判定を評価: 04〜09 月=前期 / それ以外=後期。**08・09 月もエラーなく前期**判定
- SC2155 修正の実証: 分離前 `$?`=0 (バグ) → 分離後 `$?`=実終了コード
- Docker ビルド成功 + **イメージ内で `TZ='JST-9'` が +9h 正確に効く**ことを確認 (busybox + tzdata なし)