### PR TITLE
docs: bump pinning examples from v1.0.0 to v1.2.0

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,14 +30,14 @@ INDIVIDUAL_MODE=true DOCUMENT_NAME=my-paper /bin/bash -c "$(curl -fsSL https://r
 
 **Version pinning (reproducibility & safety)**: The commands above default to `main`
 (latest) for convenience. To pin a specific version, replace `main` in the URL with a
-release tag (e.g. `v1.0.0`); the script body and the content it clones internally are
+release tag (e.g. `v1.2.0`); the script body and the content it clones internally are
 both pinned to that tag. The internal ref can also be overridden via `UNIVERSAL_REF`
 (precedence: `UNIVERSAL_REF` > `UNIVERSAL_BRANCH` > embedded default `main`).
 See [docs/RELEASE.md](docs/RELEASE.md) for the release workflow.
 
 ```bash
 # Pinned version
-/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/smkwlab/student-repo-management/v1.0.0/create-repo/setup.sh)" bash thesis
+/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/smkwlab/student-repo-management/v1.2.0/create-repo/setup.sh)" bash thesis
 ```
 
 ### Branch Protection Setup

--- a/create-repo/README.md
+++ b/create-repo/README.md
@@ -49,11 +49,11 @@ STUDENT_ID=k21rs001 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com
 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/smkwlab/student-repo-management/v1/create-repo/setup.sh)" bash thesis
 
 # 特定パッチに完全固定（厳密な再現が必要な場合）
-/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/smkwlab/student-repo-management/v1.0.0/create-repo/setup.sh)" bash thesis
+/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/smkwlab/student-repo-management/v1.2.0/create-repo/setup.sh)" bash thesis
 ```
 
 > `v1` は「最新の v1 系リリース」を指す移動タグです（GitHub Actions の `@v4` と同様）。
-> 完全に同一の内容を再現したい場合は `v1.0.0` のように具体的なバージョンを指定してください。
+> 完全に同一の内容を再現したい場合は `v1.2.0` のように具体的なバージョンを指定してください。
 
 > 変更するのは **URL 内の `main` の部分だけ**です。コマンド末尾の引数（上の例では
 > `bash thesis`。`bash` は `bash -c` のダミー引数 `$0`、`thesis` が実際の文書タイプ `$1`）や、
@@ -61,7 +61,7 @@ STUDENT_ID=k21rs001 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com
 
 - スクリプトの内容は公開リポジトリでいつでも確認できます。実行前に内容を確認したい場合は、
   上記 URL をブラウザで開いて確認してください。
-- 利用可能なバージョン（`v1.0.0` などの具体的なリリース）は [Releases](https://github.com/smkwlab/student-repo-management/releases) を参照してください。なお `v1` はそれらの最新を指す移動タグ（ポインタ）であり、Releases 一覧には個別の項目としては現れません。
+- 利用可能なバージョン（`v1.2.0` などの具体的なリリース）は [Releases](https://github.com/smkwlab/student-repo-management/releases) を参照してください。なお `v1` はそれらの最新を指す移動タグ（ポインタ）であり、Releases 一覧には個別の項目としては現れません。
 - リリース運用の詳細は [docs/RELEASE.md](../docs/RELEASE.md) を参照してください。
 
 ## よくある質問

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -123,9 +123,9 @@ git push origin v1 --force
 
 ```bash
 # タグ付き URL の EMBEDDED_REF がタグ値になっているか
-curl -fsSL https://raw.githubusercontent.com/smkwlab/student-repo-management/v1.0.0/create-repo/setup.sh \
+curl -fsSL https://raw.githubusercontent.com/smkwlab/student-repo-management/v1.2.0/create-repo/setup.sh \
   | grep '^EMBEDDED_REF='
-# => EMBEDDED_REF="v1.0.0"
+# => EMBEDDED_REF="v1.2.0"
 
 # main 側は "main" のまま
 curl -fsSL https://raw.githubusercontent.com/smkwlab/student-repo-management/main/create-repo/setup.sh \
@@ -150,7 +150,7 @@ URL のブランチ部分をタグに変えるだけで、本体・内部 clone 
 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/smkwlab/student-repo-management/v1/create-repo/setup.sh)" bash thesis
 
 # 特定パッチに完全固定（厳密な再現が必要な場合）
-/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/smkwlab/student-repo-management/v1.0.0/create-repo/setup.sh)" bash thesis
+/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/smkwlab/student-repo-management/v1.2.0/create-repo/setup.sh)" bash thesis
 ```
 
 ### 参照先を明示的に上書きしたい場合


### PR DESCRIPTION
## 概要

v1.2.0 リリースに合わせ、docs 内の**バージョン固定(ピン留め)の例示**を最新リリース `v1.2.0` に更新する。

学生向けの参照は移動タグ `/v1/` を使っており v1.2.0 を自動配信するため対象外。今回更新するのは student-repo-management 自身の docs にある「ピン留めのやり方」を示す例示だけ。エコシステム全体の参照監査の結果、`/v1.0.0/` を指していたのはこれらの例示のみだった。

## 背景

v1.0.0 は**統合前(#516 以前・旧 5 スクリプト構成)**のリリースのため、読者が例示コマンドをそのままコピーすると古い挙動を掴んでしまう。例示値を現行 v1.2.0 に更新して回避する。

## 変更内容

| ファイル | 箇所 |
|---|---|
| `CLAUDE.md` | Version pinning の `e.g. v1.0.0` とコマンド例 |
| `create-repo/README.md` | 特定パッチ固定のコマンド例 + 説明文中の例示 2 箇所 |
| `docs/RELEASE.md` | 検証手順の URL と期待出力 (`=> EMBEDDED_REF=...`) のペア、固定版コマンド例 |

計 `+8 / -8` 行。

## 据え置いた v1.0.0(正当なため)

- `docs/RELEASE.md` の**リリース手順ウォークスルー**(「例として `v1.0.0` をリリースする場合」の一連の git コマンド) — 手順の worked example として一貫しており、特定リリースに書き換えるとかえって紛らわしいため維持。
- `README.md` の changelog エントリ(`v1.0.0 (2024/04): 基本システム完成`) — 履歴の事実。

## 検証

- `/v1.0.0/create-repo/setup.sh` の URL 参照がゼロになったことを確認。