### PR TITLE
feat(setup): add ASSUME_YES non-interactive mode

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -117,6 +117,7 @@ INDIVIDUAL_MODE=true           # Skip student ID input, create in personal accou
 
 # Non-interactive execution (auto-approve the confirmation prompt)
 ASSUME_YES=1                   # Skip the "続行しますか?" confirmation; run without a TTY
+# Accepted truthy values: 1 / true / TRUE / yes / YES (setup.sh normalizes to true internally)
 # Works for all document types, independent of INDIVIDUAL_MODE (e.g. bulk creation, CI).
 # setup.sh validates that the inputs needed to avoid any remaining prompt are present
 # and fails fast before launching the container if any are missing:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -115,8 +115,23 @@ INDIVIDUAL_MODE=true           # Skip student ID input, create in personal accou
 # Note: When INDIVIDUAL_MODE=true, any STUDENT_ID argument is ignored
 # Note: Individual mode automatically disables Registry Manager integration
 
+# Non-interactive execution (auto-approve the confirmation prompt)
+ASSUME_YES=1                   # Skip the "続行しますか?" confirmation; run without a TTY
+# Works for all document types, independent of INDIVIDUAL_MODE (e.g. bulk creation, CI).
+# setup.sh validates that the inputs needed to avoid any remaining prompt are present
+# and fails fast before launching the container if any are missing:
+#   - thesis/wr/ise : STUDENT_ID required (organization flow)
+#   - latex         : STUDENT_ID (organization flow) + DOCUMENT_NAME
+#   - poster        : STUDENT_ID (organization flow) + POSTER_NAME or DOCUMENT_NAME
+# Under INDIVIDUAL_MODE=true, STUDENT_ID is not required (only the name inputs above).
+
 # ISE report configuration
 ISE_REPORT_NUM=1              # Report number (1 or 2)
+```
+
+```bash
+# Non-interactive organization-flow example (no prompts, no TTY needed)
+STUDENT_ID=k21rs001 ASSUME_YES=1 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/smkwlab/student-repo-management/main/create-repo/setup.sh)" bash thesis
 ```
 
 ## Student ID Patterns

--- a/create-repo/common-lib.sh
+++ b/create-repo/common-lib.sh
@@ -46,6 +46,12 @@ command_exists() { command -v "$1" >/dev/null 2>&1; }
 # 各所に散在する [[ "$INDIVIDUAL_MODE" =~ ... ]] と同一の判定（Issue #516）
 is_individual_mode() { [[ "$INDIVIDUAL_MODE" =~ ^(true|TRUE|1|yes|YES)$ ]]; }
 
+# ASSUME_YES 判定（真なら 0 を返す）
+# 確認プロンプト（confirm_creation）を自動承認する非対話フラグ。個人アカウント
+# 作成を意味する INDIVIDUAL_MODE とは独立で、組織フローの非対話実行にも使う
+# （Issue #527）。setup.sh が docker run 時に -e ASSUME_YES=true を注入する。
+is_assume_yes() { [[ "$ASSUME_YES" =~ ^(true|TRUE|1|yes|YES)$ ]]; }
+
 # ================================
 # 初期化・設定関数
 # ================================
@@ -381,7 +387,13 @@ confirm_creation() {
         echo "📋 個人モード: 自動的に続行します"
         return 0
     fi
-    
+
+    # ASSUME_YES の場合も自動承認（組織フローの非対話実行。Issue #527）
+    if is_assume_yes; then
+        echo "📋 ASSUME_YES: 確認を省略して続行します"
+        return 0
+    fi
+
     read -p "続行しますか? [Y/n]: " -n 1 -r
     echo ""
     

--- a/create-repo/setup.sh
+++ b/create-repo/setup.sh
@@ -595,17 +595,62 @@ if [[ -n "$MSYSTEM" ]] || [[ "$OSTYPE" == "msys" ]] || [[ -n "$MINGW_PREFIX" ]] 
     fi
 fi
 
-# 対話的入力が必要かどうかを判断。
-# 非対話にできるのは「INDIVIDUAL_MODE（confirm_creation が自動承認）」かつ「名前が env で
-# 指定済み（名前プロンプトが出ない）」の場合のみ。latex は DOCUMENT_NAME、poster は
-# POSTER_NAME か DOCUMENT_NAME があれば非対話にできる（Issue #519 で poster を追加）。
-# poster で DOCUMENT_NAME のみ指定の場合も非対話で問題ない: コンテナ側 read_poster_name は
-# POSTER_NAME 未設定時に DOCUMENT_NAME を poster 名として採用する（フォールバック）ため、
-# 名前プロンプトは出ない。両方指定時は POSTER_NAME が優先される（env 転送・採用とも同順）。
+# 対話的入力が必要かどうかを判断。非対話実行のパスは 2 つ:
+#
+#  1) ASSUME_YES（Issue #527）: 確認プロンプト（コンテナ側 confirm_creation）を
+#     自動承認し、全タイプで非対話実行する。組織フローでも使える汎用フラグで、
+#     INDIVIDUAL_MODE（個人アカウント作成）とは独立。ただし名前・学籍番号の入力
+#     プロンプトは自動承認では消えないため、必要な入力が揃っていることを前提とする
+#     （揃っていなければ下でエラー終了する）。
+#  2) INDIVIDUAL_MODE（従来・Issue #519）: 個人モードでは confirm_creation が
+#     自動承認されるため、「名前が env 指定済み（名前プロンプトが出ない）」なら
+#     非対話にできる。latex は DOCUMENT_NAME、poster は POSTER_NAME か DOCUMENT_NAME が
+#     あればよい（poster は read_poster_name が POSTER_NAME 未設定時に DOCUMENT_NAME を
+#     採用するフォールバックのため。両方指定時は POSTER_NAME 優先）。thesis/wr/ise は
+#     従来どおり -it 付きで実行する（挙動不変）。
 # 注: set -e 下で `[ ... ] && VAR=...` は左辺 false で終了してしまうため if 構造で書く。
+
+# ASSUME_YES 非対話実行に必要な入力の欠落を ", " 区切りで返す（無ければ空文字）。
+# コンテナ側 main.sh が出すプロンプトに対応する:
+#  - 組織モード（INDIVIDUAL_MODE でない）は全タイプで read_student_id_if_needed が
+#    STUDENT_ID を要求する（空だと read_student_id が対話 or GitHub ユーザー名へ誤フォールバック）。
+#  - latex は read_document_name が DOCUMENT_NAME、poster は read_poster_name が
+#    POSTER_NAME/DOCUMENT_NAME を要求する。
+missing_noninteractive_inputs() {
+    local missing=""
+    if ! [[ "$INDIVIDUAL_MODE" =~ ^(true|TRUE|1|yes|YES)$ ]] && [ -z "$STUDENT_ID" ]; then
+        missing="STUDENT_ID"
+    fi
+    case "$DOC_TYPE" in
+        latex)
+            if [ -z "$DOCUMENT_NAME" ]; then
+                missing="${missing:+$missing, }DOCUMENT_NAME"
+            fi
+            ;;
+        poster)
+            if [ -z "$POSTER_NAME" ] && [ -z "$DOCUMENT_NAME" ]; then
+                missing="${missing:+$missing, }POSTER_NAME/DOCUMENT_NAME"
+            fi
+            ;;
+    esac
+    printf '%s' "$missing"
+}
+
 DOCKER_OPTIONS="--rm"
 INTERACTIVE=true
-if [[ "$INDIVIDUAL_MODE" =~ ^(true|TRUE|1|yes|YES)$ ]]; then
+if [[ "${ASSUME_YES:-}" =~ ^(true|TRUE|1|yes|YES)$ ]]; then
+    # 入力欠落のまま非対話にすると、コンテナ内で EOF が空回答＝Yes と誤解釈されたり
+    # STUDENT_ID が GitHub ユーザー名へ誤フォールバックする。コンテナ起動前に止める。
+    MISSING_INPUTS=$(missing_noninteractive_inputs)
+    if [ -n "$MISSING_INPUTS" ]; then
+        echo "❌ ASSUME_YES での非対話実行には次の入力が必要です（$DOC_TYPE）: $MISSING_INPUTS" >&2
+        echo "   組織フローの例: STUDENT_ID=k21rs001 ASSUME_YES=1 ... bash $DOC_TYPE" >&2
+        exit 1
+    fi
+    # コンテナ側 confirm_creation を自動承認させる（正規化済みの true を転送）
+    DOCKER_ENV_VARS="$DOCKER_ENV_VARS -e ASSUME_YES=true"
+    INTERACTIVE=false
+elif [[ "$INDIVIDUAL_MODE" =~ ^(true|TRUE|1|yes|YES)$ ]]; then
     case "$DOC_TYPE" in
         latex)
             if [ -n "$DOCUMENT_NAME" ]; then INTERACTIVE=false; fi


### PR DESCRIPTION
## 概要

`setup.sh` の非対話実行を `INDIVIDUAL_MODE`(個人アカウント作成)から分離し、**組織下の学生フロー(thesis/wr/ise、および latex/poster)を TTY なしで実行できる**汎用フラグ `ASSUME_YES` を追加する。一括作成・作成フロー自体の CI テスト・他 org 展開(#105)時の検証自動化に使える。

Resolves #527

## 背景

従来の非対話パスは「`INDIVIDUAL_MODE=true` かつ名前が env 指定済み(latex→`DOCUMENT_NAME`、poster→`POSTER_NAME`/`DOCUMENT_NAME`)」に限られ、非対話化が個人モードに結び付いていた。組織フローでは `STUDENT_ID` を渡しても、コンテナ側 `confirm_creation`(`read -p "続行しますか?"`)が `INDIVIDUAL_MODE` のときしか自動承認せず、`setup.sh` の `INTERACTIVE` 判定も同様のため `-it` が付いたままだった(TTY の無い CI では `docker run -it` が落ちうる)。

## 変更内容

- **`setup.sh`**: 全タイプで `ASSUME_YES` を尊重。真のときは**残プロンプトを消すのに必要な入力が揃っているか検証**し、欠落時は**コンテナ起動前に**明確なメッセージでエラー終了する。
  - 組織モード: 全タイプで `STUDENT_ID` 必須
  - latex: 上記 + `DOCUMENT_NAME`
  - poster: 上記 + `POSTER_NAME` または `DOCUMENT_NAME`
  - これによりコンテナ内で EOF が「空＝Yes」と誤承認されたり、`STUDENT_ID` が GitHub ユーザー名へ誤フォールバックする事故を防ぐ。正規化済みの `-e ASSUME_YES=true` を転送し、`-it` を落とす。
- **`common-lib.sh`**: `is_assume_yes()` を追加し、`confirm_creation` で `INDIVIDUAL_MODE` と同様に自動承認する。
- **後方互換**: `INDIVIDUAL_MODE` 単独の既存非対話パス、および `-it` 付き実行の挙動は不変。
- **`CLAUDE.md`**: `ASSUME_YES` とタイプ別の必須入力を記載。

## 手動検証(docker 未起動・ロジック単体)

`set -e` 下で以下を確認済み(GitHub 上に repo を作らないためコンテナは起動せず、判定ブロック／`confirm_creation`／必須入力判定を逐語再現して検証):

- **正常系**: thesis+id / latex+id+name / individual+ASSUME_YES+latex+name → `INTERACTIVE=false`・`-it` 無し・`ASSUME_YES=true` 転送
- **異常系**: thesis(id 欠落) / latex(name 欠落) → コンテナ起動前に `exit 1`(欠落項目を明示)
- **後方互換**: individual+latex+name は従来どおり非対話(`ASSUME_YES` 転送なし)、individual thesis / 組織 thesis は従来どおり `-it` 維持
- **`confirm_creation`**: org+ASSUME_YES→自動承認、org+フラグ無し→従来プロンプト、individual→従来どおり、未設定変数でもエラーなし(`set -u` 不使用を確認)
- `bash -n` 構文チェック 3 ファイル OK、`shellcheck -S warning` は既存箇所のみ(変更部分の指摘なし)

## レビュー観点

- 必須入力の検証条件(組織モードで全タイプ `STUDENT_ID` 必須)がコンテナ側 `main.sh` のプロンプト実態と一致しているか
- `ASSUME_YES` と `INDIVIDUAL_MODE` 併用時の分岐(elif で `INDIVIDUAL_MODE` パスをスキップ)が妥当か