### PR TITLE
feat: reopen registration issues closed without completed protection

### DIFF
--- a/.github/workflows/verify-protection-on-close.yml
+++ b/.github/workflows/verify-protection-on-close.yml
@@ -57,9 +57,14 @@ jobs:
 
           problems=""
 
-          # レジストリ登録の確認
-          repo_type=$(gh api "repos/${REGISTRY_REPO}/contents/data/registry.json" \
-            --jq '.content' | base64 -d | \
+          # レジストリ登録の確認（取得自体の失敗は一時障害の可能性があるため、
+          # 未登録と区別して検証をスキップし、誤リオープンを避ける）
+          if ! reg_content=$(gh api "repos/${REGISTRY_REPO}/contents/data/registry.json" \
+            --jq '.content' 2>&1); then
+            echo "::warning::レジストリの取得に失敗したため検証をスキップします: $reg_content"
+            exit 0
+          fi
+          repo_type=$(echo "$reg_content" | base64 -d | \
             jq -r --arg r "$repo_name" '.[$r].repository_type // empty')
 
           if [ -z "$repo_type" ]; then
@@ -82,11 +87,16 @@ jobs:
           esac
 
           if [ "$needs_protection" = "true" ]; then
-            if gh api "repos/${target}/branches/main/protection" --silent 2>/dev/null; then
+            # 404（未保護）と 403・ネットワーク障害等を区別する。
+            # 一時障害での誤リオープンを避け、判定できないときはスキップする
+            if api_err=$(gh api "repos/${target}/branches/main/protection" 2>&1 >/dev/null); then
               echo "main ブランチ保護: 設定済み"
-            else
+            elif echo "$api_err" | grep -q "HTTP 404"; then
               problems="${problems}- \`${target}\` の main ブランチ保護が未設定です
           "
+            else
+              echo "::warning::ブランチ保護の確認に失敗したため検証をスキップします: $api_err"
+              exit 0
             fi
           fi
 
@@ -96,7 +106,7 @@ jobs:
           fi
 
           echo "::warning::未完了の項目があるため Issue #${ISSUE_NUMBER} を再オープンします"
-          gh issue reopen "$ISSUE_NUMBER" --repo "$THIS_REPO"
+          # 通知を受けた管理者が Issue を開いた時点で理由が見えるよう、コメントを先に投稿する
           gh issue comment "$ISSUE_NUMBER" --repo "$THIS_REPO" --body \
           "⚠️ この登録依頼 Issue はクローズされましたが、未完了の項目があるため自動で再オープンしました。
 
@@ -111,3 +121,4 @@ jobs:
           3. 復旧を確認してから Issue をクローズする
 
           リポジトリ作成の取りやめ等で対応せずにクローズする場合は、クローズ時に **Close as not planned** を選択してください（not_planned ではこのチェックは動作しません）。"
+          gh issue reopen "$ISSUE_NUMBER" --repo "$THIS_REPO"

--- a/.github/workflows/verify-protection-on-close.yml
+++ b/.github/workflows/verify-protection-on-close.yml
@@ -1,0 +1,113 @@
+---
+# 登録依頼 Issue のクローズ時ガード（Issue #530）
+#
+# 自動処理が失敗した登録依頼 Issue を、リカバリ（ブランチ保護設定・レジストリ
+# 登録）の完了前に手動クローズすると、未保護リポジトリが検出不能になる。
+# クローズ時に実状態を検証し、未完了ならリオープンして警告する。
+#
+# - bot による正常クローズは保護設定済みのため素通しする
+# - 作成取りやめ等で意図的にクローズする場合は「Close as not planned」を
+#   選択する（state_reason=not_planned はこのガードの対象外）
+name: Verify Protection on Close
+
+"on":
+  issues:
+    types: [closed]
+
+jobs:
+  verify-protection:
+    runs-on: ubuntu-latest
+    # リポジトリ登録依頼の Issue のみで実行
+    if: >
+      contains(github.event.issue.title || '', 'リポジトリ登録依頼') &&
+      github.event.issue.state_reason != 'not_planned'
+    env:
+      # 規約: <org>/thesis-student-registry。逸脱時のみ org/repo variable
+      # REGISTRY_REPO で override（ECOSYSTEM.md: Organization-Scoped Deployment）
+      REGISTRY_REPO: ${{ vars.REGISTRY_REPO || format('{0}/thesis-student-registry', github.repository_owner) }}
+    steps:
+      # GitHub App の installation token を毎回発行する（PAT の無通知失効を排除）。
+      # 学生リポジトリのブランチ保護参照とレジストリ参照に cross-repo token が必要
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1  # v3.2.0
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+
+      - name: Verify registration and branch protection
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          ISSUE_TITLE: ${{ github.event.issue.title }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          THIS_REPO: ${{ github.repository }}
+        run: |
+          set -eu
+
+          # タイトルから対象リポジトリを抽出
+          # 例: 「📋 リポジトリ登録依頼: smkwlab/k24rs001-ise-report1」
+          target=$(echo "$ISSUE_TITLE" | grep -oE '[A-Za-z0-9][A-Za-z0-9-]*/[A-Za-z0-9._-]+' | head -1 || true)
+          if [ -z "$target" ]; then
+            echo "::warning::Issue タイトルからリポジトリ名を抽出できないため検証をスキップします: $ISSUE_TITLE"
+            exit 0
+          fi
+          repo_name="${target#*/}"
+          echo "検証対象: $target"
+
+          problems=""
+
+          # レジストリ登録の確認
+          repo_type=$(gh api "repos/${REGISTRY_REPO}/contents/data/registry.json" \
+            --jq '.content' | base64 -d | \
+            jq -r --arg r "$repo_name" '.[$r].repository_type // empty')
+
+          if [ -z "$repo_type" ]; then
+            problems="${problems}- レジストリ（${REGISTRY_REPO}）に \`${repo_name}\` が登録されていません
+          "
+          else
+            echo "repository_type: $repo_type"
+          fi
+
+          # ブランチ保護の確認（保護必須の種別のみ。wr / latex / other は保護不要）
+          # 未登録で種別が不明な場合も、保護必須種別の命名規則に一致すれば確認する
+          needs_protection=false
+          case "$repo_type" in
+            sotsuron|master|ise) needs_protection=true ;;
+            "")
+              if echo "$repo_name" | grep -qE -- '-(sotsuron|master|thesis|ise-report[0-9]*)$'; then
+                needs_protection=true
+              fi
+              ;;
+          esac
+
+          if [ "$needs_protection" = "true" ]; then
+            if gh api "repos/${target}/branches/main/protection" --silent 2>/dev/null; then
+              echo "main ブランチ保護: 設定済み"
+            else
+              problems="${problems}- \`${target}\` の main ブランチ保護が未設定です
+          "
+            fi
+          fi
+
+          if [ -z "$problems" ]; then
+            echo "✅ 登録とブランチ保護を確認しました。クローズを許可します"
+            exit 0
+          fi
+
+          echo "::warning::未完了の項目があるため Issue #${ISSUE_NUMBER} を再オープンします"
+          gh issue reopen "$ISSUE_NUMBER" --repo "$THIS_REPO"
+          gh issue comment "$ISSUE_NUMBER" --repo "$THIS_REPO" --body \
+          "⚠️ この登録依頼 Issue はクローズされましたが、未完了の項目があるため自動で再オープンしました。
+
+          ## 未完了の項目
+
+          ${problems}
+          ## 管理者向けリカバリ手順
+
+          1. ブランチ保護: \`scripts/setup-branch-protection.sh ${repo_name}\` を実行
+             （registry-manager が PATH にあれば registry の protection_status 記録まで自動）
+          2. レジストリ登録: \`registry-manager add ${repo_name}\` で再登録
+          3. 復旧を確認してから Issue をクローズする
+
+          リポジトリ作成の取りやめ等で対応せずにクローズする場合は、クローズ時に **Close as not planned** を選択してください（not_planned ではこのチェックは動作しません）。"

--- a/scripts/process-pending-issues.sh
+++ b/scripts/process-pending-issues.sh
@@ -1746,7 +1746,16 @@ comment_processing_failure() {
         run_url=" 実行ログ: ${GITHUB_SERVER_URL:-https://github.com}/${GITHUB_REPOSITORY:-$REPO}/actions/runs/${GITHUB_RUN_ID}"
     fi
 
-    add_issue_comment "$issue_number" "⚠️ 自動処理に失敗しました（${reason}）。管理者が対応するまでこの Issue は open のままです。${run_url}"
+    # リカバリ手順を明記する（issue #530: 復旧前の手動クローズによる取りこぼし防止。
+    # 未復旧のままクローズしても verify-protection-on-close.yml が再オープンする）
+    add_issue_comment "$issue_number" "⚠️ 自動処理に失敗しました（${reason}）。管理者が対応するまでこの Issue は open のままです。${run_url}
+
+## 管理者向けリカバリ手順
+
+1. 上記の実行ログで失敗原因を確認する
+2. ブランチ保護の失敗: \`scripts/setup-branch-protection.sh ${CURRENT_REPO_NAME:-<repo>}\` を再実行する（registry-manager が PATH にあれば registry の protection_status 記録まで自動）
+3. レジストリ登録の失敗: \`registry-manager add ${CURRENT_REPO_NAME:-<repo>}\` で再登録する
+4. 復旧を確認してからこの Issue をクローズする（未復旧のままクローズすると自動で再オープンされます。リポジトリ作成の取りやめ等は **Close as not planned** でクローズしてください）"
 }
 
 add_issue_comment() {


### PR DESCRIPTION
## 概要

一括作成時に自動処理が失敗した登録依頼 Issue を、リカバリ完了前に手動クローズすると未保護リポジトリが検出不能になる問題 (#530) の再発防止です。2026-07-08 に k24rs*-ise-report1 の 7/10 件が未保護のまま約 1 週間放置された事例に基づきます。

Resolves #530

## 変更内容

### 新規: `.github/workflows/verify-protection-on-close.yml` (クローズ時ガード)

登録依頼 Issue (`リポジトリ登録依頼` をタイトルに含む) の `issues: closed` イベントで発火し:

1. Issue タイトルから対象リポジトリを抽出
2. **レジストリ登録を確認** (`data/registry.json` に `repository_type` があるか)
3. **保護必須種別 (sotsuron / master / ise) なら main のブランチ保護を実確認**。未登録で種別不明の場合は、リポジトリ名の命名規則 (`-sotsuron` / `-master` / `-thesis` / `-ise-report*`) で補助判定
4. 未完了があれば **Issue を自動リオープン**し、リカバリ手順 (setup-branch-protection.sh の再実行、registry-manager での再登録) をコメント

設計上のポイント:

- bot による正常クローズは保護設定済みのため素通し (追加コメントなし)
- 作成取りやめ等の意図的なクローズは **Close as not planned** で可能 (`state_reason != 'not_planned'` ガード)。リオープンループの escape hatch
- wr / latex / other 種別は保護不要のため保護チェックをスキップ (登録確認のみ)
- 既存ワークフローと同じ GitHub App installation token 方式 (cross-repo でブランチ保護とレジストリを参照)
- #495 の教訓に従い、イベントの Issue 番号を直接使用

### 変更: `scripts/process-pending-issues.sh` (失敗コメントの改善)

失敗コメントに管理者向けリカバリ手順 (ログ確認 → `setup-branch-protection.sh` 再実行 → `registry-manager add` 再登録 → 復旧確認後にクローズ、not planned の使い分け) を追記。既存の冪等ガード (「自動処理に失敗しました」の grep) は維持しています。

## スコープ外

#530 の対応 2 (registry と実設定の定期監査) は規模が異なるため #531 に切り出しました。本ガードは「登録依頼 Issue のクローズ」を通る経路のみを守り、Issue を経由しない作成や事後の保護解除は #531 でカバーします。

## 検証

- `yamllint` (リポジトリの `.yamllint.yml`): pass
- 埋め込みスクリプトを抽出して `shellcheck`: pass
- `bash -n scripts/process-pending-issues.sh`: pass
- 実環境での動作確認は merge 後に k19rs999 系テストリポジトリで実施予定 (登録依頼 Issue を未保護状態でクローズ → リオープンされること、not planned で素通しされること)