### PR TITLE
feat: add weekly branch protection audit

### DIFF
--- a/.github/workflows/audit-branch-protection.yml
+++ b/.github/workflows/audit-branch-protection.yml
@@ -1,0 +1,44 @@
+---
+# ブランチ保護の定期監査（Issue #531）
+#
+# registry（thesis-student-registry）の記録と GitHub の実設定を週次で
+# 突き合わせ、乖離があればレポート Issue を起票する。
+# クローズ時ガード（verify-protection-on-close.yml）のセーフティネット:
+# 登録依頼 Issue を経由しない作成経路や、設定後の保護解除も検出する。
+name: Audit Branch Protection
+
+"on":
+  schedule:
+    # 毎週月曜 09:00 JST（00:00 UTC）
+    - cron: "0 0 * * 1"
+  workflow_dispatch:
+
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+    env:
+      # 規約: <org>/thesis-student-registry。逸脱時のみ org/repo variable
+      # REGISTRY_REPO で override（ECOSYSTEM.md: Organization-Scoped Deployment）
+      REGISTRY_REPO: ${{ vars.REGISTRY_REPO || format('{0}/thesis-student-registry', github.repository_owner) }}
+    steps:
+      # GitHub App の installation token を毎回発行する（PAT の無通知失効を排除）。
+      # 学生リポジトリのブランチ保護参照・レジストリ参照・Issue 起票に
+      # cross-repo token が必要
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1  # v3.2.0
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+
+      - name: Checkout repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+
+      - name: Audit branch protection
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          bash scripts/audit-branch-protection.sh

--- a/scripts/audit-branch-protection.sh
+++ b/scripts/audit-branch-protection.sh
@@ -1,0 +1,184 @@
+#!/bin/bash
+#
+# Branch Protection Audit Script
+#
+# レジストリ（thesis-student-registry の data/registry.json）と GitHub の
+# 実設定を突き合わせ、乖離を検出する（issue #531）。
+#
+# クローズ時ガード（verify-protection-on-close.yml、issue #530）のセーフティ
+# ネット: 登録依頼 Issue を経由しないリポジトリ作成や、設定後の保護解除、
+# registry 記録との乖離を定期的に検出する。
+#
+# Usage:
+#   ./audit-branch-protection.sh            # 乖離があれば Issue を起票/追記
+#   ./audit-branch-protection.sh --dry-run  # レポートを標準出力のみ（検証用）
+#
+# Environment:
+#   REGISTRY_REPO  レジストリデータリポジトリ（owner/repo。
+#                  default: smkwlab/thesis-student-registry）。
+#                  監査対象リポジトリの owner はこの値の owner を使用する
+#   REPORT_REPO    乖離レポート Issue の起票先（owner/repo。
+#                  default: $GITHUB_REPOSITORY、無ければ
+#                  smkwlab/student-repo-management）
+#
+# 監査対象:
+#   - repository_type が sotsuron / master / ise のエントリ（保護必須種別）
+#   - archived リポジトリは対象外（過年度分の恒常的なノイズを防ぐ）
+#
+# 分類:
+#   critical  main が実際に未保護（本来あってはならない状態）
+#   drift     実際は保護済みだが registry の protection_status が不一致
+#   stale     registry に存在するが GitHub にリポジトリが無い
+#   errors    一時的なエラーで確認できなかった（判定保留）
+
+set -eu
+
+REGISTRY_REPO="${REGISTRY_REPO:-smkwlab/thesis-student-registry}"
+REPORT_REPO="${REPORT_REPO:-${GITHUB_REPOSITORY:-smkwlab/student-repo-management}}"
+AUDIT_ISSUE_TITLE="🔍 ブランチ保護監査: 乖離を検出"
+
+DRY_RUN=false
+if [ "${1:-}" = "--dry-run" ]; then
+    DRY_RUN=true
+fi
+
+org="${REGISTRY_REPO%%/*}"
+
+workdir=$(mktemp -d)
+trap 'rm -rf "$workdir"' EXIT
+
+log() {
+    echo "[$(date +'%Y-%m-%d %H:%M:%S')] $1"
+}
+
+log "レジストリを取得中: ${REGISTRY_REPO}"
+registry=$(gh api "repos/${REGISTRY_REPO}/contents/data/registry.json" \
+    --jq '.content' | base64 -d)
+
+# 保護必須種別（sotsuron / master / ise）のみ監査対象
+mapfile -t repos < <(echo "$registry" | jq -r '
+    to_entries[]
+    | select(.value.repository_type as $t | ["sotsuron", "master", "ise"] | index($t))
+    | .key')
+
+log "監査対象: ${#repos[@]} リポジトリ（保護必須種別のみ）"
+
+checked=0
+skipped_archived=0
+
+for name in "${repos[@]}"; do
+    reg_status=$(echo "$registry" | jq -r --arg r "$name" \
+        '.[$r].protection_status // "(未記録)"')
+
+    # リポジトリの存在と archived を確認
+    if ! archived=$(gh api "repos/${org}/${name}" --jq '.archived' 2>&1); then
+        if echo "$archived" | grep -q "HTTP 404"; then
+            echo "- \`${name}\`: レジストリに存在するが GitHub にリポジトリが無い" \
+                >> "$workdir/stale.txt"
+        else
+            echo "- \`${name}\`: リポジトリ情報の取得に失敗（判定保留）" \
+                >> "$workdir/errors.txt"
+        fi
+        continue
+    fi
+
+    if [ "$archived" = "true" ]; then
+        skipped_archived=$((skipped_archived + 1))
+        continue
+    fi
+
+    checked=$((checked + 1))
+
+    # main の保護状態を実確認（404 = 未保護、それ以外のエラーは判定保留）
+    if prot_err=$(gh api "repos/${org}/${name}/branches/main/protection" 2>&1 >/dev/null); then
+        if [ "$reg_status" != "protected" ]; then
+            echo "- \`${org}/${name}\`: 実際は保護済みだが registry の記録は \`${reg_status}\`" \
+                >> "$workdir/drift.txt"
+        fi
+    elif echo "$prot_err" | grep -q "HTTP 404"; then
+        echo "- \`${org}/${name}\`: main が未保護（registry の記録: \`${reg_status}\`）" \
+            >> "$workdir/critical.txt"
+    else
+        echo "- \`${name}\`: 保護状態の確認に失敗（判定保留）" >> "$workdir/errors.txt"
+    fi
+done
+
+log "確認完了: ${checked} 件（archived スキップ: ${skipped_archived} 件）"
+
+if [ ! -s "$workdir/critical.txt" ] && [ ! -s "$workdir/drift.txt" ] && \
+   [ ! -s "$workdir/stale.txt" ] && [ ! -s "$workdir/errors.txt" ]; then
+    log "✅ 乖離はありません"
+    if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
+        echo "## ブランチ保護監査: 乖離なし（${checked} 件確認）" >> "$GITHUB_STEP_SUMMARY"
+    fi
+    exit 0
+fi
+
+# レポート本文の組み立て
+{
+    echo "定期監査（issue #531）で registry と GitHub 実設定の乖離を検出しました。"
+    echo ""
+    if [ -s "$workdir/critical.txt" ]; then
+        echo "## 🚨 未保護（要対応）"
+        echo ""
+        cat "$workdir/critical.txt"
+        echo ""
+        echo "対応: \`scripts/setup-branch-protection.sh <repo>\` を実行" \
+             "（registry-manager が PATH にあれば registry 記録まで自動）。"
+        echo "過年度分など監査対象から外すべきものは、リポジトリを archive してください。"
+        echo ""
+    fi
+    if [ -s "$workdir/drift.txt" ]; then
+        echo "## 📝 registry 記録の乖離"
+        echo ""
+        cat "$workdir/drift.txt"
+        echo ""
+        echo "対応: \`registry-manager protect <repo>\` で記録を更新。"
+        echo ""
+    fi
+    if [ -s "$workdir/stale.txt" ]; then
+        echo "## 👻 レジストリの孤児エントリ"
+        echo ""
+        cat "$workdir/stale.txt"
+        echo ""
+        echo "対応: リポジトリ名の変更・削除を確認し、\`registry-manager update / remove\` で整合を取る。"
+        echo ""
+    fi
+    if [ -s "$workdir/errors.txt" ]; then
+        echo "## ⚠️ 確認できなかったもの（判定保留）"
+        echo ""
+        cat "$workdir/errors.txt"
+        echo ""
+    fi
+    echo "---"
+    echo "確認: ${checked} 件 / archived スキップ: ${skipped_archived} 件 /" \
+         "実行: $(date '+%Y-%m-%d %H:%M:%S %Z')"
+} > "$workdir/report.md"
+
+if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
+    cat "$workdir/report.md" >> "$GITHUB_STEP_SUMMARY"
+fi
+
+if [ "$DRY_RUN" = "true" ]; then
+    log "--dry-run: 以下のレポートを出力のみ（Issue は起票しません）"
+    echo "========================================"
+    cat "$workdir/report.md"
+    exit 0
+fi
+
+# 既存の open な監査 Issue があればコメント追記（毎週の重複起票を防ぐ）
+existing=$(gh issue list --repo "$REPORT_REPO" --state open \
+    --search "in:title ブランチ保護監査" \
+    --json number --jq '.[0].number // empty')
+
+if [ -n "$existing" ]; then
+    log "既存の監査 Issue #${existing} にコメントを追記します"
+    gh issue comment "$existing" --repo "$REPORT_REPO" --body-file "$workdir/report.md"
+else
+    log "監査 Issue を起票します"
+    gh issue create --repo "$REPORT_REPO" \
+        --title "$AUDIT_ISSUE_TITLE" \
+        --body-file "$workdir/report.md"
+fi
+
+log "⚠️ 乖離を検出しました。詳細はレポート Issue を参照してください"

--- a/scripts/audit-branch-protection.sh
+++ b/scripts/audit-branch-protection.sh
@@ -35,7 +35,10 @@ set -eu
 
 REGISTRY_REPO="${REGISTRY_REPO:-smkwlab/thesis-student-registry}"
 REPORT_REPO="${REPORT_REPO:-${GITHUB_REPOSITORY:-smkwlab/student-repo-management}}"
-AUDIT_ISSUE_TITLE="🔍 ブランチ保護監査: 乖離を検出"
+# 既存 Issue の検索キーワードと起票タイトルを一元管理する
+# （MARKER は in:title 検索に使うため、検索構文と衝突する記号を含めない）
+AUDIT_ISSUE_MARKER="ブランチ保護監査"
+AUDIT_ISSUE_TITLE="🔍 ${AUDIT_ISSUE_MARKER}: 乖離を検出"
 
 DRY_RUN=false
 if [ "${1:-}" = "--dry-run" ]; then
@@ -52,8 +55,10 @@ log() {
 }
 
 log "レジストリを取得中: ${REGISTRY_REPO}"
+# @base64d で gh (gojq) 内で直接デコードする（外部 base64 コマンドの
+# 実装差に依存しない。折返し改行入りの content も扱える）
 registry=$(gh api "repos/${REGISTRY_REPO}/contents/data/registry.json" \
-    --jq '.content' | base64 -d)
+    --jq '.content | @base64d')
 
 # 保護必須種別（sotsuron / master / ise）のみ監査対象
 mapfile -t repos < <(echo "$registry" | jq -r '
@@ -168,7 +173,7 @@ fi
 
 # 既存の open な監査 Issue があればコメント追記（毎週の重複起票を防ぐ）
 existing=$(gh issue list --repo "$REPORT_REPO" --state open \
-    --search "in:title ブランチ保護監査" \
+    --search "in:title ${AUDIT_ISSUE_MARKER}" \
     --json number --jq '.[0].number // empty')
 
 if [ -n "$existing" ]; then


### PR DESCRIPTION
## 概要

registry (`data/registry.json`) の記録と GitHub の実設定を週次で突き合わせる定期監査を追加します。クローズ時ガード (#532) のセーフティネットで、登録依頼 Issue を経由しない作成経路や設定後の保護解除、registry 記録の乖離を検出します。

Resolves #531

## 変更内容

### 新規: `scripts/audit-branch-protection.sh`

- 保護必須種別 (sotsuron / master / ise) の registry エントリ全件について、main のブランチ保護を実確認
- **分類**: 🚨 critical (実際に未保護) / 📝 drift (保護済みだが registry 記録が不一致) / 👻 stale (registry にあるが GitHub に無い) / ⚠️ errors (一時エラー、判定保留)
- **archived リポジトリはスキップ** (過年度分の恒常的ノイズを防止。「active の判定」はこれで対応)
- 乖離があれば REPORT_REPO (本リポジトリ) に Issue を起票。**open な監査 Issue が既にあればコメント追記**して週次の重複起票を防止
- `--dry-run` でレポートを標準出力のみ (ローカル検証用)
- 404 とそれ以外のエラーを区別し、一時障害は「判定保留」として誤検知を避ける (#532 と同じ方針)

### 新規: `.github/workflows/audit-branch-protection.yml`

週次 cron (月曜 09:00 JST) + `workflow_dispatch`。既存ワークフローと同じ GitHub App installation token 方式です。

## 実環境での検証 (--dry-run)

実 org に対して実行し、正しく動作することを確認済みです:

- 監査対象 14 件を確認、**drift 8 件を実際に検出** (保護済みだが `protection_status` 未記録: 2026-07-08 の一括作成で成功した k24rs023/088/122、k24rs062、k19rs999、k24gjk02/04/06-master)
- 昨日 `setup-branch-protection.sh` 経由で保護した 6 件は記録済みのため検出されない (分類ロジックの傍証)
- critical / stale / errors は 0 件

検出済み drift は merge 前でも `registry-manager protect <repo>` × 8 で解消可能です (未実施)。

## 既知の制限

registry に存在しないリポジトリは監査できません (例: registry 導入前の過年度リポジトリ `k22rs005-ise-report1` は未保護だが対象外)。org 全リポジトリの命名規則ベースの走査は、必要になれば別 Issue で拡張します。