### PR TITLE
ci: serve setup.sh at short URL via GitHub Pages

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -13,11 +13,6 @@ on:
       - .github/workflows/pages.yml
   workflow_dispatch:
 
-permissions:
-  contents: read
-  pages: write
-  id-token: write
-
 concurrency:
   group: pages
   cancel-in-progress: false
@@ -26,6 +21,11 @@ jobs:
   build:
     runs-on: ubuntu-latest
     name: Build Pages artifact
+    permissions:
+      contents: read
+      # configure-pages reads the Pages site metadata (GET /repos/*/pages) and
+      # fails the job if that call is denied.
+      pages: read
     steps:
       - name: Checkout repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
@@ -37,7 +37,8 @@ jobs:
           # keeps a migration path. Content-Type is irrelevant to bash <(...).
           cp create-repo/setup.sh _site/index.html
           cp create-repo/setup.sh _site/setup.sh
-          echo repo-setup.smkwlab.net > _site/CNAME
+          # No CNAME file: Actions-based Pages deploys ignore it. The custom
+          # domain lives in Settings -> Pages (or the pages API) instead.
           touch _site/.nojekyll
 
       - name: Configure Pages
@@ -52,6 +53,9 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     name: Deploy to GitHub Pages
+    permissions:
+      pages: write
+      id-token: write
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,61 @@
+---
+# Publish create-repo/setup.sh at the short URL https://repo-setup.smkwlab.net
+# so students can run: bash <(curl -fsSL https://repo-setup.smkwlab.net) thesis
+# create-repo/setup.sh stays the single source; this workflow copies it to the
+# Pages artifact (root index.html + /setup.sh alias) on every main update.
+name: Deploy setup.sh to Pages
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - create-repo/setup.sh
+      - .github/workflows/pages.yml
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    name: Build Pages artifact
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+
+      - name: Assemble site from setup.sh
+        run: |
+          mkdir -p _site
+          # Root (index.html) is what a path-less curl fetches; the .sh alias
+          # keeps a migration path. Content-Type is irrelevant to bash <(...).
+          cp create-repo/setup.sh _site/index.html
+          cp create-repo/setup.sh _site/setup.sh
+          echo repo-setup.smkwlab.net > _site/CNAME
+          touch _site/.nojekyll
+
+      - name: Configure Pages
+        uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3
+        with:
+          path: _site
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    name: Deploy to GitHub Pages
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4


### PR DESCRIPTION
## 目的

学生に案内しているリポジトリ作成コマンドが長すぎるため短縮する。

**現行:**
```bash
/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/smkwlab/student-repo-management/main/create-repo/setup.sh)" bash thesis
```

**目標:**
```bash
bash <(curl -fsSL https://repo-setup.smkwlab.net) thesis
```

## この PR の範囲（フェーズ A のみ）

`create-repo/setup.sh` を `https://repo-setup.smkwlab.net` で配信する GitHub Pages デプロイ workflow (`.github/workflows/pages.yml`) を追加する。**この PR 単体ではまだ短縮 URL は有効にならない**（DNS と Pages 設定が別途必要 — 下記参照）。ドキュメントの書き換えも新 URL 検証後の別 PR で行う。

## 設計

- **単一ソース維持**: `create-repo/setup.sh` を唯一のソースとして維持し、workflow が Pages アーティファクトへコピーする（二重管理を避ける）。
- **パスなしルート配信**: ルート `index.html` に `setup.sh` の内容をコピー。`bash <(curl ...)` は本文をバイト列として読むだけなので `Content-Type: text/html` は無関係。`/setup.sh` エイリアスと `.nojekyll` も同梱。
- **公式 Actions**: `actions/upload-pages-artifact` + `actions/deploy-pages`（`gh-pages` ブランチや PAT 不要）。すべて SHA 固定 + バージョンコメント（既存 workflow の慣習に準拠）。
- **トリガ**: `create-repo/setup.sh` または本 workflow の `main` push、および `workflow_dispatch`（手動再デプロイ用）。

## なぜ `curl | bash` ではなくプロセス置換か

通常フローは `docker run -it`（`setup.sh:666`）で学籍番号入力・確認プロンプトを対話する。`curl ... | bash` のパイプ形式は stdin をスクリプト本文に奪われ対話が壊れる。プロセス置換 `bash <(curl ...)` は stdin を端末に残すため対話が維持される。

## マージ後に必要な手動作業（リポジトリ外）

1. **DNS**: `repo-setup.smkwlab.net` の CNAME レコード → `smkwlab.github.io`
2. **Settings → Pages**: Source = GitHub Actions、Custom domain = `repo-setup.smkwlab.net`
3. DNS 伝播 + TLS 証明書発行を待って Enforce HTTPS
4. 新 URL の動作検証後、ドキュメント一括更新（別 PR）

## 検証

- [x] `yamllint -c .yamllint.yml` … warning のみ（既存 workflow と同種、pass）
- [x] `actionlint` … エラーなし
- [ ] マージ後に `workflow_dispatch` でデプロイ成功を確認
- [ ] `curl -fsSL https://repo-setup.smkwlab.net | head` で `#!/bin/bash` が返ることを確認
