### PR TITLE
fix: serve the v1 release setup.sh at the short URL, not main

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,16 +1,23 @@
 ---
-# Publish create-repo/setup.sh at the short URL https://repo-setup.smkwlab.net
-# so students can run: bash <(curl -fsSL https://repo-setup.smkwlab.net) thesis
-# create-repo/setup.sh stays the single source; this workflow copies it to the
-# Pages artifact (root index.html + /setup.sh alias) on every main update.
+# Publish the stable create-repo/setup.sh at the short URL
+# https://repo-setup.smkwlab.net so students can run:
+#   bash <(curl -fsSL https://repo-setup.smkwlab.net) thesis
+#
+# This serves the v1 moving tag, NOT main. Student-executed commands must not
+# track main, or unreleased changes reach students (see #122); the documented
+# one-liners point at v1 for the same reason. The v1 setup.sh also carries
+# EMBEDDED_REF="v1.x.y", so the template content it clones is pinned to that
+# same release -- serving main would silently unpin both halves.
+#
+# Deploys when a release tag is pushed. The run that matters is the v1 move in
+# step 7 of docs/RELEASE.md; a vX.Y.Z push earlier in that procedure also fires
+# but still publishes whatever v1 points at, so the final state is correct
+# either way. Use workflow_dispatch to redeploy without a release.
 name: Deploy setup.sh to Pages
 
 on:
   push:
-    branches: [main]
-    paths:
-      - create-repo/setup.sh
-      - .github/workflows/pages.yml
+    tags: ['v*']
   workflow_dispatch:
 
 concurrency:
@@ -27,8 +34,13 @@ jobs:
       # fails the job if that call is denied.
       pages: read
     steps:
-      - name: Checkout repository
+      - name: Checkout the stable release (v1 moving tag)
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          # Pin to v1 regardless of what triggered the run, so a dispatch from
+          # main never publishes main's setup.sh. Bump this when the stable
+          # series moves to v2, together with the one-liners in the docs.
+          ref: v1
 
       - name: Assemble site from setup.sh
         run: |
@@ -40,6 +52,18 @@ jobs:
           # No CNAME file: Actions-based Pages deploys ignore it. The custom
           # domain lives in Settings -> Pages (or the pages API) instead.
           touch _site/.nojekyll
+
+      - name: Verify the artifact is a release, not main
+        run: |
+          # A release setup.sh embeds its own tag; main embeds "main". Publishing
+          # the latter would point students at unreleased template content, which
+          # is exactly what serving v1 avoids -- fail loudly instead.
+          ref=$(sed -n 's/^EMBEDDED_REF="\(.*\)"$/\1/p' _site/index.html)
+          if [ -z "$ref" ] || [ "$ref" = "main" ]; then
+            echo "::error::Refusing to publish setup.sh with EMBEDDED_REF=\"${ref:-<unset>}\"; expected a release tag."
+            exit 1
+          fi
+          echo "Publishing setup.sh from ${ref}."
 
       - name: Configure Pages
         uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -76,11 +76,26 @@ gh release create v1.0.0 --title "v1.0.0" --notes "リリース内容..."
 #    （v1 がタグオブジェクトを指すと解決が不安定になるのを防ぐ）
 git tag -f v1 v1.0.0^{}
 git push origin v1 --force
+
+# 8. 短縮 URL の再デプロイを確認（v1 の push で自動実行される）
+#    配信内容が新しいリリースに入れ替わったことを確かめる
+curl -fsSL https://repo-setup.smkwlab.net | grep EMBEDDED_REF
 ```
 
 > **重要**: リリース用コミット（`EMBEDDED_REF="v1.0.0"`）を `main` にマージしないこと。
 > マージすると `main` の `setup.sh` が古いタグを指し続けてしまう。
 > `main` 上の `EMBEDDED_REF` は常に `"main"` を保つ。
+
+### 短縮 URL への反映
+
+短縮 URL `https://repo-setup.smkwlab.net` は `v1` の `setup.sh` を配信しており
+（[`.github/workflows/pages.yml`](../.github/workflows/pages.yml)）、手順 7 の
+`v1` push で自動的に再デプロイされる。`main` への push では**再デプロイされない**
+（学生が未リリースの変更を踏まないようにするため）。
+
+反映されない場合は Actions から `Deploy setup.sh to Pages` を `workflow_dispatch`
+で手動実行する。workflow は配信前に `EMBEDDED_REF` を検証し、`main` を配信しよう
+とした場合は失敗する。
 
 ## メジャー移動タグ（`v1` など）
 


### PR DESCRIPTION
## 概要

#536 で追加した Pages workflow は `main` を checkout していたため、`https://repo-setup.smkwlab.net` が `EMBEDDED_REF="main"` の `setup.sh` を配信していた。これは **#122 の維持者決定と矛盾する**ため修正する。

> Per AI review and maintainer decision: student-executed commands must not track main — unreleased changes would reach students. (c620bd0 / #122)

`docs/RELEASE.md` の「固定の二段構造」がまさにこの問題を説明している。`main` を配信すると**二段固定の両方が同時に外れる**:

| | 短縮 URL (修正前) | v1 タグ |
| --- | --- | --- |
| ① スクリプト本体 | main 追従 | v1.3.0 で固定 |
| ② 本体が clone する内容 (`EMBEDDED_REF`) | `"main"` | `"v1.3.0"` |

学生向けワンライナーが全 20 箇所 `v1` に統一されているのはこの理由によるもので、**このままでは短縮 URL は #536 が意図した置き換え先になれなかった**。ドキュメント更新 (#536 の手順4) の前提としてこれを直す。

短縮 URL はまだどのドキュメントにも記載していないため、学生への影響は発生していない。

## 変更内容

### `.github/workflows/pages.yml`

- **トリガを `push: branches: [main]` → `push: tags: ['v*']` に変更**。未リリースの `setup.sh` は配信しない
- **`checkout` に `ref: v1` を指定**。トリガに関わらず v1 を配信するので、`main` からの手動 dispatch でも main の `setup.sh` が出ることはない
- **配信前の検証ステップを追加**。`EMBEDDED_REF` が `main` または欠損なら `::error::` で失敗させ、この不具合が再発しても気づかないまま公開されないようにする

```console
$ # ローカルでガードの挙動を確認
v1 の setup.sh   → PASS (v1.3.0)
main の setup.sh → REJECT (EMBEDDED_REF="main")
EMBEDDED_REF なし → REJECT (EMBEDDED_REF="<unset>")
```

### `docs/RELEASE.md`

- リリース手順に手順8(短縮 URL の反映確認)を追加
- 「短縮 URL への反映」節を追加 — `v1` push で自動再デプロイされること、`main` push では再デプロイされないこと、手動 dispatch のフォールバック

## 補足: マージ後に一度だけ手動 dispatch が必要

現在の `v1` (= v1.3.0 = 5b0617a) は #536 より前のコミットで、**`pages.yml` を含まない**。そのため `v1` を動かしても workflow は発火せず、また現在の短縮 URL は main 由来の内容を配信したままになっている。

マージ後に `Deploy setup.sh to Pages` を `workflow_dispatch` で一度手動実行し、配信内容を v1 に入れ替える必要がある。次回リリース (v1.4.0 以降) からは `v1` に `pages.yml` が含まれるため自動化される。

## 検証

- [x] `yamllint -c .yamllint.yml` … pass
- [x] `actionlint` … エラーなし
- [x] 検証ステップのロジックを v1 / main / 欠損の3ケースでローカル実行し、期待どおり PASS / REJECT / REJECT
- [ ] マージ後に `workflow_dispatch` を実行し、`curl -fsSL https://repo-setup.smkwlab.net | grep EMBEDDED_REF` が `v1.3.0` を返すことを確認
