### PR TITLE
docs: remove stale review-branch and nonexistent script references

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,7 +38,7 @@ release workflow.
 
 ```bash
 # Pinned to an exact release
-bash <(curl -fsSL https://raw.githubusercontent.com/smkwlab/student-repo-management/v1.2.0/create-repo/setup.sh) thesis
+bash <(curl -fsSL https://raw.githubusercontent.com/smkwlab/student-repo-management/v1.3.0/create-repo/setup.sh) thesis
 ```
 
 ### Branch Protection Setup
@@ -195,9 +195,6 @@ DEBUG=1 STUDENT_ID=k21rs001 ./create-repo/setup.sh
 
 ### Emergency Manual Operations
 ```bash
-# Manual review branch update
-./scripts/update-review-branch.sh repo-name branch-name
-
 # Validate repository structure
 gh repo view smkwlab/repo-name --json defaultBranch,visibility
 ```

--- a/README.md
+++ b/README.md
@@ -312,11 +312,11 @@ git push -u origin {next-branch}
 ### 開発・テスト環境
 
 ```bash
-# テスト用リポジトリ作成
-./scripts/create-student-repos.sh test-student
+# テスト用リポジトリ作成（create-repo/main.sh を直接実行）
+cd create-repo && DOC_TYPE=thesis ./main.sh k21rs999
 
 # 動作確認
-cd test-student-sotsuron
+cd k21rs999-sotsuron
 # 通常の学生ワークフローをテスト
 ```
 

--- a/create-repo/README.md
+++ b/create-repo/README.md
@@ -45,11 +45,11 @@ STUDENT_ID=k21rs001 bash <(curl -fsSL https://repo-setup.smkwlab.net) wr
 
 ```bash
 # 特定パッチに完全固定（厳密な再現が必要な場合）
-bash <(curl -fsSL https://raw.githubusercontent.com/smkwlab/student-repo-management/v1.2.0/create-repo/setup.sh) thesis
+bash <(curl -fsSL https://raw.githubusercontent.com/smkwlab/student-repo-management/v1.3.0/create-repo/setup.sh) thesis
 ```
 
 > 短縮 URL は「最新の `v1` 系リリース」を配信します（`v1` は GitHub Actions の `@v4` と
-> 同様の移動タグです）。完全に同一の内容を再現したい場合のみ、`v1.2.0` のように具体的な
+> 同様の移動タグです）。完全に同一の内容を再現したい場合のみ、`v1.3.0` のように具体的な
 > バージョンを指定してください。
 
 > 変更するのは **URL の部分だけ**です。コマンド末尾の文書タイプ（上の例では `thesis`）や、
@@ -58,7 +58,7 @@ bash <(curl -fsSL https://raw.githubusercontent.com/smkwlab/student-repo-managem
 - スクリプトの内容は公開リポジトリでいつでも確認できます。実行前に内容を確認したい場合は、
   [v1 の setup.sh](https://github.com/smkwlab/student-repo-management/blob/v1/create-repo/setup.sh)
   を開いてください（短縮 URL が配信しているものと同じ内容です）。
-- 利用可能なバージョン（`v1.2.0` などの具体的なリリース）は [Releases](https://github.com/smkwlab/student-repo-management/releases) を参照してください。なお `v1` はそれらの最新を指す移動タグ（ポインタ）であり、Releases 一覧には個別の項目としては現れません。
+- 利用可能なバージョン（`v1.3.0` などの具体的なリリース）は [Releases](https://github.com/smkwlab/student-repo-management/releases) を参照してください。なお `v1` はそれらの最新を指す移動タグ（ポインタ）であり、Releases 一覧には個別の項目としては現れません。
 - リリース運用の詳細は [docs/RELEASE.md](../docs/RELEASE.md) を参照してください。
 
 ## よくある質問

--- a/docs/CLAUDE-DEVELOPMENT.md
+++ b/docs/CLAUDE-DEVELOPMENT.md
@@ -95,11 +95,9 @@ Sophisticated GitHub Actions-based supervision:
 **Branch Strategy:**
 - `initial`: Base state for clean diff tracking
 - `0th-draft`, `1st-draft`, `2nd-draft`, etc.: Sequential development
-- `review-branch`: Persistent branch for holistic review (auto-updated)
 
 **Faculty Workflow:**
 - **Differential review**: Each draft PR shows changes from previous version
-- **Comprehensive review**: `review-branch` PR shows entire document content
 - **GitHub suggestions**: Direct edit capabilities for faculty
 - **Auto-management**: Students close PRs after addressing feedback
 
@@ -115,8 +113,7 @@ create-repo/
 └── README.md                   # Usage instructions
 
 scripts/
-├── update-review-branch.sh     # Emergency manual review branch update
-└── (other management scripts)
+└── (management scripts)
 
 docs/
 └── (developer documentation: CLAUDE-*.md, RELEASE.md, etc.)

--- a/docs/CLAUDE-EXAMPLES.md
+++ b/docs/CLAUDE-EXAMPLES.md
@@ -65,9 +65,6 @@ cd create-repo && DOC_TYPE=wr ./main.sh k21rs001
 
 ### Manual Repository Management (Emergency Use)
 ```bash
-# Update review branch manually (emergency only)
-./scripts/update-review-branch.sh {repo-name} {branch-name}
-
 # Validate repository structure
 gh repo view {org}/{repo-name} --json defaultBranch,visibility
 ```

--- a/docs/CLAUDE-TROUBLESHOOTING.md
+++ b/docs/CLAUDE-TROUBLESHOOTING.md
@@ -62,7 +62,7 @@ docker run --rm --entrypoint gh -e GH_TOKEN="$(gh auth token)" thesis-creator au
 ### Repository Creation Debugging
 ```bash
 # Enable debug mode for detailed output
-DEBUG=1 STUDENT_ID=k21rs001 /bin/bash -c "$(curl -fsSL ...)"
+DEBUG=1 STUDENT_ID=k21rs001 bash <(curl -fsSL https://repo-setup.smkwlab.net) thesis
 
 # Verify student ID patterns
 echo "k21rs001" | grep -E "k[0-9]{2}rs[0-9]{3}" && echo "undergraduate" || echo "graduate"

--- a/docs/CLAUDE-WORKFLOWS.md
+++ b/docs/CLAUDE-WORKFLOWS.md
@@ -28,10 +28,9 @@ Further improvements → Final PR → Faculty approval → final-* tag → Auto-
 
 ### Review Process
 1. **Monitor draft PRs** for incremental changes
-2. **Use review-branch PR** for holistic document review
-3. **Provide feedback** via GitHub comments and suggestions
-4. **Track progress** through branch sequence
-5. **Final approval** through GitHub workflow
+2. **Provide feedback** via GitHub comments and suggestions
+3. **Track progress** through branch sequence
+4. **Final approval** through GitHub workflow
 
 ### Management Tools
 - **Progress tracking**: Via GitHub repository insights

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -138,9 +138,9 @@ git push origin v1 --force
 
 ```bash
 # タグ付き URL の EMBEDDED_REF がタグ値になっているか
-curl -fsSL https://raw.githubusercontent.com/smkwlab/student-repo-management/v1.2.0/create-repo/setup.sh \
+curl -fsSL https://raw.githubusercontent.com/smkwlab/student-repo-management/v1.3.0/create-repo/setup.sh \
   | grep '^EMBEDDED_REF='
-# => EMBEDDED_REF="v1.2.0"
+# => EMBEDDED_REF="v1.3.0"
 
 # main 側は "main" のまま
 curl -fsSL https://raw.githubusercontent.com/smkwlab/student-repo-management/main/create-repo/setup.sh \
@@ -164,7 +164,7 @@ URL をタグ付きの raw URL に変えるだけで、本体・内部 clone と
 
 ```bash
 # 特定パッチに完全固定（厳密な再現が必要な場合）
-bash <(curl -fsSL https://raw.githubusercontent.com/smkwlab/student-repo-management/v1.2.0/create-repo/setup.sh) thesis
+bash <(curl -fsSL https://raw.githubusercontent.com/smkwlab/student-repo-management/v1.3.0/create-repo/setup.sh) thesis
 ```
 
 ### 参照先を明示的に上書きしたい場合

--- a/scripts/process-pending-issues.sh
+++ b/scripts/process-pending-issues.sh
@@ -1014,7 +1014,7 @@ show_issue_details() {
             echo "  2. Issue クローズ"
             ;;
         ise|sotsuron|master)
-            echo "  1. ブランチ保護設定 (main, review-branch)"
+            echo "  1. ブランチ保護設定 (main)"
             echo "  2. thesis-student-registry への登録"
             echo "  3. Issue クローズ"
             ;;
@@ -1376,7 +1376,6 @@ process_thesis_with_feedback() {
 
 ## ブランチ保護設定
 - **main ブランチ**: 1つ以上の承認レビューが必要
-- **review-branch**: 存在する場合は同様に保護
 - **新しいコミット時**: 古いレビューを無効化
 - **フォースプッシュ**: 禁止
 - **ブランチ削除**: 禁止
@@ -1391,7 +1390,7 @@ process_thesis_with_feedback() {
     
     echo ""
     echo "📋 実行された操作:"
-    echo "  • ブランチ保護設定 (main, review-branch)"
+    echo "  • ブランチ保護設定 (main)"
     echo "  • thesis-student-registry への登録"
     echo "  • Issue #$CURRENT_ISSUE_NUMBER のクローズ"
     echo ""
@@ -1628,7 +1627,6 @@ process_thesis_issue() {
 
 ## ブランチ保護設定
 - **main ブランチ**: 1つ以上の承認レビューが必要
-- **review-branch**: 存在する場合は同様に保護
 - **新しいコミット時**: 古いレビューを無効化
 - **フォースプッシュ**: 禁止
 - **ブランチ削除**: 禁止
@@ -1674,7 +1672,6 @@ process_ise_issue() {
 
 ## ブランチ保護設定
 - **main ブランチ**: 1つ以上の承認レビューが必要
-- **review-branch**: 1つ以上の承認レビューが必要
 - **新しいコミット時**: 古いレビューを無効化
 - **フォースプッシュ**: 禁止
 - **ブランチ削除**: 禁止


### PR DESCRIPTION
## 概要

エコシステム全体のドキュメント監査で見つかった陳腐化記述の修正です。かつて存在した「review-branch / レビュー用 PR」機構は sotsuron-template PR #74(2025-10-31)で削除済みで、現行モデルは draft 連鎖 PR のみです。ブランチ保護も `setup-branch-protection.sh` の実装どおり main のみが対象ですが、ドキュメントとスクリプトの案内メッセージに旧モデルの記述が残っていました。

## 変更内容

- 実在しない `scripts/update-review-branch.sh` への参照を削除(`CLAUDE.md`、`docs/CLAUDE-DEVELOPMENT.md`、`docs/CLAUDE-EXAMPLES.md`)
- `docs/CLAUDE-DEVELOPMENT.md` の Branch Strategy / Faculty Workflow、`docs/CLAUDE-WORKFLOWS.md` の Review Process から review-branch 機構の説明を削除
- `README.md` の実在しない `scripts/create-student-repos.sh` を、現行のテスト方法(`cd create-repo && DOC_TYPE=thesis ./main.sh k21rs999`)に書き換え
- `docs/CLAUDE-TROUBLESHOOTING.md` の旧 curl 形式を現行の短縮 URL 形式(`bash <(curl -fsSL https://repo-setup.smkwlab.net) thesis`)に更新
- `scripts/process-pending-issues.sh` の案内メッセージ 5 箇所を実態(main のみ保護)に修正(echo/heredoc の文字列のみ、ロジック変更なし。`bash -n` で構文確認済み)
- バージョンピン例を `v1.2.0` → `v1.3.0` に更新(`CLAUDE.md`、`create-repo/README.md`、`docs/RELEASE.md`。タグ v1.3.0 の実在確認済み)

## 検証

- `command grep -rn "update-review-branch\|create-student-repos\|review-branch" . --include='*.md' --include='*.sh'`(テスト生成物除外)→ 0 件
- `./scripts/validate-yaml.sh` → all checks passed

https://claude.ai/code/session_01PGcVXHJSHMBx4ki8WU2ZiS