### PR TITLE
feat: add REVIEW_FLOW opt-in for latex repositories

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,7 +66,7 @@ For manual branch protection setup or troubleshooting:
 gh repo view smkwlab/k21rs001-sotsuron --json branchProtectionRules
 ```
 
-**Note**: Weekly reports (wr-template) and general LaTeX documents (latex-template) do not use branch protection as they have simpler workflows. ISE reports (ise-report-template) and posters (poster-template) use the same PR-based branch protection as thesis repositories.
+**Note**: Weekly reports (wr-template) do not use branch protection as they have simpler workflows. General LaTeX documents (latex-template) do not use it by default either, but opt in via `REVIEW_FLOW=true` at creation time. ISE reports (ise-report-template) and posters (poster-template) always use the same PR-based branch protection as thesis repositories.
 
 ## Key Files & Structure
 
@@ -112,6 +112,9 @@ Universal Setup Script uses `DOC_TYPE` environment variable to specify document 
 ```bash
 # LaTeX document configuration
 DOCUMENT_NAME=research-note    # Custom document name
+
+# Draft PR review flow opt-in (DOC_TYPE=latex only; thesis/ise/poster are always on, wr unsupported)
+REVIEW_FLOW=true               # Initialize main + 0th-draft, enable auto-assign, apply branch protection
 
 # Individual mode behavior (DOC_TYPE=latex only)
 INDIVIDUAL_MODE=true           # Skip student ID input, create in personal account

--- a/create-repo/common-lib.sh
+++ b/create-repo/common-lib.sh
@@ -543,14 +543,24 @@ generate_issue_body() {
     local repo_name="$2"
     local student_id="$3"
     local repo_type="${4:-latex}"  # デフォルトは最も汎用的な latex タイプ
-    
+
+    # latex は作成時オプトイン（REVIEW_FLOW）でレビューフローの有無が分かれるため、
+    # 有効時のみ Issue に記録し、process-pending-issues がブランチ保護の要否を
+    # 判定できるようにする（他タイプはタイプ自体で要否が決まるため記載しない）。
+    # USE_DRAFT_FLOW は main.sh のグローバル。未定義の呼び出し元では従来どおり空
+    local review_flow_line=""
+    if [ "$repo_type" = "latex" ] && [ "${USE_DRAFT_FLOW:-false}" = true ]; then
+        review_flow_line="- **レビューフロー**: on"
+    fi
+
     cat << EOF
 ## リポジトリ登録依頼
 
 ### リポジトリ情報
 - **リポジトリ**: [${organization}/${repo_name}](https://github.com/${organization}/${repo_name})
 - **学生ID**: ${student_id}
-- **リポジトリタイプ**: ${repo_type}
+- **リポジトリタイプ**: ${repo_type}${review_flow_line:+
+$review_flow_line}
 - **作成日時**: $(date '+%Y-%m-%d %H:%M') JST
 
 ### 処理内容

--- a/create-repo/main.sh
+++ b/create-repo/main.sh
@@ -35,8 +35,8 @@ DOC_TYPE="${DOC_TYPE:?DOC_TYPE を指定してください (thesis|wr|latex|ise|
 # SCRIPT_TITLE / SCRIPT_EMOJI: init_script_common の引数
 # STUDENT_ID_EXAMPLES: 学籍番号プロンプトの例示（空なら read_student_id の既定）
 # RUN_ALDC: aldc による LaTeX 環境セットアップを行うか（ise は HTML ベースのため行わない）
-# SETUP_AUTO_ASSIGN: 組織メンバー向け auto-assign 設定を追加するか（thesis / ise / poster）
-# USE_DRAFT_FLOW: main + 0th-draft のドラフトレビューワークフローを使うか（thesis / ise / poster）
+# SETUP_AUTO_ASSIGN: 組織メンバー向け auto-assign 設定を追加するか（thesis / ise / poster、latex は REVIEW_FLOW 指定時）
+# USE_DRAFT_FLOW: main + 0th-draft のドラフトレビューワークフローを使うか（thesis / ise / poster、latex は REVIEW_FLOW 指定時）
 case "$DOC_TYPE" in
     thesis)
         SCRIPT_TITLE="論文リポジトリセットアップツール"
@@ -82,6 +82,14 @@ case "$DOC_TYPE" in
         die "サポートされていない文書タイプ: $DOC_TYPE (thesis|wr|latex|ise|poster)"
         ;;
 esac
+
+# REVIEW_FLOW: latex 専用のオプトイン。draft PR レビューフロー（main + 0th-draft
+# 初期化・auto-assign）を有効化する。setup.sh が truthy を true に正規化して
+# 転送するが、コンテナを直接実行する経路にも効かせるため本体側でも truthy 判定する
+if [ "$DOC_TYPE" = "latex" ] && [[ "${REVIEW_FLOW:-}" =~ ^(true|TRUE|1|yes|YES)$ ]]; then
+    SETUP_AUTO_ASSIGN=true
+    USE_DRAFT_FLOW=true
+fi
 
 # 共通初期化
 init_script_common "$SCRIPT_TITLE" "$SCRIPT_EMOJI"
@@ -429,10 +437,20 @@ print_next_steps() {
 3. 毎週新しい週報ファイルを追加"
             ;;
         latex)
-            print_completion_message "次のステップ:
+            if [ "$USE_DRAFT_FLOW" = true ]; then
+                print_completion_message "次のステップ:
+1. 0th-draft ブランチで main.tex を編集して文書を作成
+2. git add, commit, pushで変更を保存
+3. Pull Request を作成して添削を依頼（次稿ブランチは自動作成されます）
+4. GitHub Actionsで自動的にPDFが生成されます
+
+📖 詳細な手順: リポジトリの README.md の「添削を受ける場合」をご確認ください"
+            else
+                print_completion_message "次のステップ:
 1. main.texを編集して文書を作成
 2. git add, commit, pushで変更を保存
 3. GitHub Actionsで自動的にPDFが生成されます"
+            fi
             ;;
         poster)
             print_completion_message "次のステップ:

--- a/create-repo/setup.sh
+++ b/create-repo/setup.sh
@@ -540,6 +540,21 @@ if [ -n "${SETUP_GIT_EMAIL_DOMAIN:-}" ]; then
     DOCKER_ENV_VARS="$DOCKER_ENV_VARS -e SETUP_GIT_EMAIL_DOMAIN=$SETUP_GIT_EMAIL_DOMAIN"
 fi
 
+# REVIEW_FLOW: latex タイプで draft PR レビューフロー（main + 0th-draft 初期化・
+# auto-assign・ブランチ保護）を有効化するオプトイン。truthy のときだけ正規化して
+# 転送する（thesis / ise / poster は常時有効、wr は非対応のため latex 以外では無視）。
+if [ -n "${REVIEW_FLOW:-}" ]; then
+    if [[ "$REVIEW_FLOW" =~ ^(true|TRUE|1|yes|YES)$ ]]; then
+        if [ "$DETECTED_DOC_TYPE" = "latex" ]; then
+            DOCKER_ENV_VARS="$DOCKER_ENV_VARS -e REVIEW_FLOW=true"
+        else
+            echo "⚠️ REVIEW_FLOW は latex タイプ専用のため無視します（$DETECTED_DOC_TYPE は指定不要: thesis/ise/poster は常時有効、wr は非対応）"
+        fi
+    else
+        echo "⚠️ REVIEW_FLOW の値が truthy ではないため無視します: $REVIEW_FLOW（有効化するには true/1/yes）"
+    fi
+fi
+
 # DOCUMENT_NAME / POSTER_NAME はコンテナ側 main.sh で ^[a-zA-Z0-9_-]+$ を要求する。
 # ここでも無引用展開（docker run $DOCKER_ENV_VARS）に載るため、同じ文字種のみ許可して
 # 単語分割・glob を防ぐ（他の転送変数と同じ流儀）。

--- a/scripts/process-pending-issues.sh
+++ b/scripts/process-pending-issues.sh
@@ -597,6 +597,15 @@ extract_issue_info() {
         return 2  # 情報抽出エラーとして区別
     fi
     
+    # レビューフロー有無の抽出（latex の作成時オプトイン REVIEW_FLOW。有効時のみ
+    # generate_issue_body が「**レビューフロー**: on」を記録する。他タイプはタイプ
+    # 自体で要否が決まるためこのフラグは latex 以外では常に false のまま）
+    CURRENT_REVIEW_FLOW=false
+    if [[ "$CURRENT_ISSUE_BODY" =~ レビューフロー[*[:space:]]*:[[:space:]]*on ]]; then
+        CURRENT_REVIEW_FLOW=true
+        log_debug "Issue #${CURRENT_ISSUE_NUMBER}: レビューフロー有効を検出"
+    fi
+
     log_debug "Issue #${CURRENT_ISSUE_NUMBER}: $CURRENT_REPO_NAME ($CURRENT_REPO_TYPE) - $CURRENT_STUDENT_ID"
     return 0
 }
@@ -1016,9 +1025,19 @@ show_issue_details() {
     
     echo "実行される処理:"
     case "$CURRENT_REPO_TYPE" in
-        wr|latex)
+        wr)
             echo "  1. thesis-student-registry への登録"
             echo "  2. Issue クローズ"
+            ;;
+        latex)
+            if [ "$CURRENT_REVIEW_FLOW" = true ]; then
+                echo "  1. ブランチ保護設定 (main)（レビューフロー有効）"
+                echo "  2. thesis-student-registry への登録"
+                echo "  3. Issue クローズ"
+            else
+                echo "  1. thesis-student-registry への登録"
+                echo "  2. Issue クローズ"
+            fi
             ;;
         ise|sotsuron|master|poster)
             echo "  1. ブランチ保護設定 (main)"
@@ -1077,7 +1096,7 @@ execute_issue_processing() {
             ;;
         latex)
             echo "→ 汎用LaTeXリポジトリの登録処理を実行中..."
-            if process_latex_with_feedback; then
+            if run_latex_with_feedback; then
                 echo "✅ 処理が完了しました"
             else
                 echo "❌ 処理に失敗しました"
@@ -1547,6 +1566,86 @@ process_poster_with_feedback() {
 }
 
 #
+# 汎用LaTeXリポジトリ処理の振り分け（詳細フィードバック付き）
+#
+# latex はレビューフロー有効時（作成時オプトイン REVIEW_FLOW、Issue 本文の
+# 「レビューフロー: on」で判定）のみブランチ保護付きの処理に分岐する
+#
+run_latex_with_feedback() {
+    if [ "$CURRENT_REVIEW_FLOW" = true ]; then
+        process_latex_review_with_feedback
+    else
+        process_latex_with_feedback
+    fi
+}
+
+#
+# 汎用LaTeXリポジトリ処理・レビューフロー有効（詳細フィードバック付き）
+#
+# draft PR サイクルを使うためブランチ保護を設定する。registry へはタイプどおり
+# latex で登録する（保護の要否は registry ではなく Issue 本文のフラグで決まる）
+#
+process_latex_review_with_feedback() {
+    echo "  📄 汎用LaTeXリポジトリ（レビューフロー有効）の処理を開始..."
+    echo ""
+
+    # 1. ブランチ保護設定（draft PR レビュー用）
+    echo "  ブランチ保護設定を適用中..."
+    if REPO_OWNER="$DEPLOY_ORG" REGISTRY_OWNER="${REGISTRY_REPO%%/*}" "$SCRIPT_DIR/setup-branch-protection.sh" "${DEPLOY_ORG}/${CURRENT_REPO_NAME}"; then
+        echo "  ✅ ブランチ保護設定完了"
+    else
+        echo "  ❌ ブランチ保護設定失敗"
+        return 1
+    fi
+
+    # 2. thesis-student-registry 更新
+    echo "  thesis-student-registry への登録中..."
+    if update_thesis_student_registry "$CURRENT_REPO_NAME" "$CURRENT_STUDENT_ID" "$CURRENT_REPO_TYPE"; then
+        echo "  ✅ thesis-student-registry への登録完了"
+    else
+        echo "  ❌ thesis-student-registry への登録失敗"
+        return 1
+    fi
+
+    # 3. Issue クローズ
+    echo "  Issue クローズ中..."
+    if close_issue_with_comment "$CURRENT_ISSUE_NUMBER" "✅ 汎用LaTeXリポジトリ（レビューフロー有効）の設定が完了しました
+
+## 設定内容
+- **リポジトリ**: ${DEPLOY_ORG}/$CURRENT_REPO_NAME
+- **学生ID**: $CURRENT_STUDENT_ID
+- **設定日時**: $(date '+%Y-%m-%d %H:%M:%S JST')
+
+## ブランチ保護設定
+- **main ブランチ**: 1つ以上の承認レビューが必要
+- **新しいコミット時**: 古いレビューを無効化
+- **フォースプッシュ**: 禁止
+- **ブランチ削除**: 禁止
+
+## 添削フローについて
+1. 0th-draft ブランチで main.tex を編集
+2. Pull Request を作成して添削を依頼
+3. レビューフィードバックを確認・対応
+4. 次稿ブランチ（1st-draft など、自動作成）で改稿を継続
+
+リポジトリ設定: https://github.com/${DEPLOY_ORG}/$CURRENT_REPO_NAME/settings/branches"; then
+        echo "  ✅ Issue #${CURRENT_ISSUE_NUMBER} をクローズしました"
+    else
+        echo "  ❌ Issue クローズに失敗しました"
+        return 1
+    fi
+
+    echo ""
+    echo "📋 実行された操作:"
+    echo "  • ブランチ保護設定 (main)"
+    echo "  • thesis-student-registry への登録"
+    echo "  • Issue #$CURRENT_ISSUE_NUMBER のクローズ"
+    echo ""
+
+    return 0
+}
+
+#
 # 汎用LaTeXリポジトリ処理（詳細フィードバック付き）
 #
 process_latex_with_feedback() {
@@ -1644,7 +1743,12 @@ process_single_issue() {
             process_poster_issue
             ;;
         latex|other)
-            process_latex_issue
+            # latex はレビューフロー有効時のみブランチ保護付きの処理に分岐する
+            if [ "$CURRENT_REPO_TYPE" = "latex" ] && [ "$CURRENT_REVIEW_FLOW" = true ]; then
+                process_latex_review_issue
+            else
+                process_latex_issue
+            fi
             ;;
         *)
             log_error "不明なリポジトリタイプ: $CURRENT_REPO_TYPE"
@@ -1824,6 +1928,52 @@ process_poster_issue() {
 }
 
 #
+# LaTeXリポジトリ処理・レビューフロー有効
+#
+# 作成時オプトイン REVIEW_FLOW 付きで作られた latex リポジトリ（Issue 本文の
+# 「レビューフロー: on」で判定）。draft PR サイクルを使うためブランチ保護を設定する
+process_latex_review_issue() {
+    log_info "LaTeXリポジトリ（レビューフロー有効）処理: $CURRENT_REPO_NAME"
+
+    # 1. thesis-student-registry への登録（タイプどおり latex で登録。保護の要否は
+    #    registry ではなく Issue 本文のフラグで決まる）
+    if ! update_thesis_student_registry "$CURRENT_REPO_NAME" "$CURRENT_STUDENT_ID" "$CURRENT_REPO_TYPE"; then
+        log_error "thesis-student-registry への登録に失敗: $CURRENT_REPO_NAME"
+        return 1
+    fi
+
+    # 2. ブランチ保護設定
+    if ! REPO_OWNER="$DEPLOY_ORG" REGISTRY_OWNER="${REGISTRY_REPO%%/*}" "$SCRIPT_DIR/setup-branch-protection.sh" "${DEPLOY_ORG}/${CURRENT_REPO_NAME}"; then
+        log_error "ブランチ保護設定に失敗: $CURRENT_REPO_NAME (学生ID: $CURRENT_STUDENT_ID)"
+        return 1
+    fi
+
+    # 3. Issue クローズ
+    if ! close_issue_with_comment "$CURRENT_ISSUE_NUMBER" "✅ 汎用LaTeXリポジトリ（レビューフロー有効）の登録とブランチ保護設定が完了しました
+
+## 処理内容
+- **リポジトリ登録**: [${DEPLOY_ORG}/$CURRENT_REPO_NAME](https://github.com/${DEPLOY_ORG}/$CURRENT_REPO_NAME) ✓
+- **ブランチ保護設定**: 完了 ✓
+- **設定日時**: $(date '+%Y-%m-%d %H:%M:%S JST')
+
+## ブランチ保護設定
+- **main ブランチ**: 1つ以上の承認レビューが必要
+- **新しいコミット時**: 古いレビューを無効化
+- **フォースプッシュ**: 禁止
+- **ブランチ削除**: 禁止
+
+## 確認
+リポジトリ設定: https://github.com/${DEPLOY_ORG}/$CURRENT_REPO_NAME/settings/branches
+
+0th-draft ブランチから Pull Request ベースの添削を開始してください。"; then
+        log_error "Issue クローズに失敗: #$CURRENT_ISSUE_NUMBER"
+        return 1
+    fi
+
+    log_success "LaTeXリポジトリ（レビューフロー有効）処理完了: $CURRENT_REPO_NAME"
+    return 0
+}
+
 # LaTeXリポジトリ処理
 #
 # latex と other の両タイプを処理する（どちらもブランチ保護なし・registry 登録


### PR DESCRIPTION
## 概要

latex タイプへの PR レビューフロー対応(Phase 2 / 2 段構えの後半、Phase 1 は smkwlab/latex-template#47)。**デフォルトは現状維持(レビューフローなし)**のまま、作成時に `REVIEW_FLOW=true` を指定すると thesis / ise / poster と同じ初期化を行うオプトインを追加します。

```bash
# 研究会予稿など、添削を受ける latex リポジトリの作成例
REVIEW_FLOW=true STUDENT_ID=k21rs001 bash <(curl -fsSL https://repo-setup.smkwlab.net) latex
```

## 変更内容

- **setup.sh**: `REVIEW_FLOW` を truthy 正規化してコンテナへ転送(latex 専用。他タイプ指定時は警告して無視 — thesis/ise/poster は常時有効、wr は非対応)
- **main.sh**: latex + REVIEW_FLOW で `USE_DRAFT_FLOW=true` + `SETUP_AUTO_ASSIGN=true`(`main` + `0th-draft` 初期化・auto-assign)。完了メッセージも PR サイクル向けに分岐
- **common-lib.sh**: 有効時のみ登録 Issue に `- **レビューフロー**: on` を記録(latex はタイプだけでは保護要否が決まらないため、Issue 本文で判別)
- **process-pending-issues.sh**: フラグを抽出し、有効な latex はブランチ保護付きの専用処理(`process_latex_review_issue` / `process_latex_review_with_feedback`)へ分岐。**registry へはタイプどおり `latex` で登録**(保護の要否は registry ではなく Issue のフラグで決まる)
- **CLAUDE.md**: REVIEW_FLOW の文書化とブランチ保護対象種別の記述更新

## 既知の制約(poster と同様)

- `audit-branch-protection` / `verify-protection-on-close` は registry の `repository_type` で対象を絞るため、REVIEW_FLOW 付き latex リポジトリは監査対象になりません(作成時の保護設定は本 PR の処理で行われます)

## 依存関係

- smkwlab/latex-template#47(テンプレートへの `prevent-draft-merge.yml` 追加)が先にマージされている必要があります