### PR TITLE
docs: unify script comments on the draft PR cycle term

### DIFF
--- a/create-repo/common-lib.sh
+++ b/create-repo/common-lib.sh
@@ -618,7 +618,7 @@ setup_review_workflow() {
 }
 
 #
-# main ブランチ確定 + ドラフトレビューワークフロー開始
+# main ブランチ確定 + draft PR サイクル開始
 #
 # main-thesis.sh / main-ise.sh で完全に重複していた「main へのセットアップ
 # コミット → push → 0th-draft ブランチ作成 → 初期ドラフト commit/push」を

--- a/create-repo/main.sh
+++ b/create-repo/main.sh
@@ -36,7 +36,7 @@ DOC_TYPE="${DOC_TYPE:?DOC_TYPE を指定してください (thesis|wr|latex|ise|
 # STUDENT_ID_EXAMPLES: 学籍番号プロンプトの例示（空なら read_student_id の既定）
 # RUN_ALDC: aldc による LaTeX 環境セットアップを行うか（ise は HTML ベースのため行わない）
 # SETUP_AUTO_ASSIGN: 組織メンバー向け auto-assign 設定を追加するか（thesis / ise / poster、latex は REVIEW_FLOW 指定時）
-# USE_DRAFT_FLOW: main + 0th-draft のドラフトレビューワークフローを使うか（thesis / ise / poster、latex は REVIEW_FLOW 指定時）
+# USE_DRAFT_FLOW: main + 0th-draft の draft PR サイクルを使うか（thesis / ise / poster、latex は REVIEW_FLOW 指定時）
 case "$DOC_TYPE" in
     thesis)
         SCRIPT_TITLE="論文リポジトリセットアップツール"


### PR DESCRIPTION
## 概要

smkwlab/latex-ecosystem#137 の用語統一の一環。管理・開発文書の独自呼称を廃止して「draft PR サイクル」に統一する方針(用語集: latex-ecosystem docs/GLOSSARY.md、同 #138)に合わせ、本リポジトリのスクリプトコメント 2 箇所の「ドラフトレビューワークフロー」を置き換えます。

## 変更内容

- `create-repo/main.sh`: `USE_DRAFT_FLOW` の説明コメント
- `create-repo/common-lib.sh`: `finalize_with_draft_flow` 前の節コメント

コメントのみの変更で、挙動の変化はありません。