### PR TITLE
docs: replace the deprecated status-field update example

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -185,8 +185,8 @@ docker build -f create-repo/Dockerfile -t test-creator .
 # Mark branch protection complete
 ./registry-manager/registry-manager protect k21rs001-sotsuron
 
-# Update repository status
-./registry-manager/registry-manager update k21rs001-sotsuron status completed
+# Update a repository field (e.g. GitHub username)
+./registry-manager/registry-manager update k21rs001-sotsuron github_username student001
 ```
 
 ### Debug Authentication Issues


### PR DESCRIPTION
## 概要

Resolves #212

`status` / `stage` フィールドはスキーマ正本(registry-manager data-structure-specification)で「削除対象(設計上不要)」と確定しており、#212 はその実行が積み残されていた状態でした。本 PR は最後のステップとして、CLAUDE.md に残っていた deprecated フィールドの操作例を有効な例(`github_username` 更新)に置き換えます。

## #212 全体の実施内容(本 PR 以外は実施済み)

1. **thesis-monitor**: status 読み取り・表示を除去 → smkwlab/thesis-monitor#39
2. **registry データ**: 該当 10 エントリ(wr 8 + other 2、全件 `status=completed` で情報量ゼロ)から status/stage を除去(SHA ガード付き PUT、他フィールド無傷をローカル diff で検証済み)。実施後の検証: `migrate status` = **47/47 v4・Require migration: 0**、`validate` の deprecated 警告ゼロ、`thesis-monitor status` 正常動作
3. **本 PR**: SRM ドキュメントの例修正

## 後続(別 Issue 化)

- registry-manager の migrate 機能削除(全データ v4 化により存在意義が消滅)
- registry-manager validate の「Legacy timestamp format」29 件(マイクロ秒付きタイムスタンプへの既存の誤検出。今回の変更とは無関係と切り分け済み)