### PR TITLE
fix: write registry entries in the current schema

### DIFF
--- a/scripts/process-pending-issues.sh
+++ b/scripts/process-pending-issues.sh
@@ -2121,9 +2121,13 @@ update_thesis_student_registry() {
 
         # 既存の github_username 配列に Issue 作成者を追加して重複排除する
         # （複数オーナー登録の保全。レガシーの string 値は配列に正規化してから統合）。
+        # 失敗時に空文字列のまま heredoc へ展開すると不正 JSON になるため即失敗させる。
         local github_username_array
-        github_username_array=$(echo "$current_json" | jq -c --arg repo_name "$repo_name" --arg u "$github_username" \
-            '(.[$repo_name].github_username // []) | if type == "string" then [.] else . end | . + [$u] | unique')
+        if ! github_username_array=$(echo "$current_json" | jq -c --arg repo_name "$repo_name" --arg u "$github_username" \
+            '(.[$repo_name].github_username // []) | if type == "string" then [.] else . end | . + [$u] | unique'); then
+            log_error "github_username 配列の生成に失敗: $repo_name"
+            return 1
+        fi
 
         local new_entry
         new_entry=$(cat <<EOF

--- a/scripts/process-pending-issues.sh
+++ b/scripts/process-pending-issues.sh
@@ -2119,6 +2119,12 @@ update_thesis_student_registry() {
             created_at="$registry_updated_at"
         fi
 
+        # 既存の github_username 配列に Issue 作成者を追加して重複排除する
+        # （複数オーナー登録の保全。レガシーの string 値は配列に正規化してから統合）。
+        local github_username_array
+        github_username_array=$(echo "$current_json" | jq -c --arg repo_name "$repo_name" --arg u "$github_username" \
+            '(.[$repo_name].github_username // []) | if type == "string" then [.] else . end | . + [$u] | unique')
+
         local new_entry
         new_entry=$(cat <<EOF
 {
@@ -2126,7 +2132,7 @@ update_thesis_student_registry() {
   "repository_type": "$repo_type",
   "created_at": "$created_at",
   "registry_updated_at": "$registry_updated_at",
-  "github_username": ["$github_username"]
+  "github_username": $github_username_array
 }
 EOF
 )

--- a/scripts/process-pending-issues.sh
+++ b/scripts/process-pending-issues.sh
@@ -2105,16 +2105,18 @@ update_thesis_student_registry() {
 
         # 新しいエントリを作成（github_usernameを含む）。既存の created_at は取り直した
         # 最新 content から拾い、並行更新による created_at の巻き戻しを防ぐ。
+        # 時刻は registry スキーマの ISO8601 UTC（registry-manager
+        # docs/data-structure-specification.md）。github_username は配列。
         # コマンド置換を含む local は宣言と代入を分離（set -e で終了コードを握り潰さない）。
-        local updated_at
-        updated_at=$(date -u '+%Y-%m-%d %H:%M:%S UTC')
+        local registry_updated_at
+        registry_updated_at=$(date -u '+%Y-%m-%dT%H:%M:%SZ')
         local created_at
         local existing_created_at
         existing_created_at=$(echo "$current_json" | jq -r --arg repo_name "$repo_name" '.[$repo_name].created_at // empty')
         if [ -n "$existing_created_at" ] && [ "$existing_created_at" != "null" ]; then
             created_at="$existing_created_at"
         else
-            created_at="$updated_at"
+            created_at="$registry_updated_at"
         fi
 
         local new_entry
@@ -2123,8 +2125,8 @@ update_thesis_student_registry() {
   "student_id": "$student_id",
   "repository_type": "$repo_type",
   "created_at": "$created_at",
-  "updated_at": "$updated_at",
-  "github_username": "$github_username"
+  "registry_updated_at": "$registry_updated_at",
+  "github_username": ["$github_username"]
 }
 EOF
 )
@@ -2144,7 +2146,7 @@ Repository: $repo_name
 Student ID: $masked_student_id
 Type: $repo_type
 GitHub Username: $github_username
-Updated: $updated_at
+Updated: $registry_updated_at
 
 Processed via automated issue processor with GitHub username."
 


### PR DESCRIPTION
## 概要

`update_thesis_student_registry` が registry.json に書き込むエントリを現行スキーマ(registry-manager docs/data-structure-specification.md)に追随させる。

Resolves #546

## 変更内容

- 廃止フィールド `updated_at`(レガシー形式 `YYYY-MM-DD HH:MM:SS UTC`)の書き込みをやめ、`registry_updated_at` を ISO8601 UTC(`%Y-%m-%dT%H:%M:%SZ`)で書く
- `github_username` を string から配列に変更
- 既存エントリの `created_at` 引き継ぎ処理は現行どおり維持

## 検証

- `bash -n` pass。shellcheck の警告は既存箇所のみで変更範囲にはなし
- 修正後の heredoc + jq mutation をローカルで再現し、生成エントリが現行スキーマどおりであることを確認(`registry_updated_at` は ISO8601 小数秒なし — registry-manager の validate は `DateTime.from_iso8601` で受理する)

https://claude.ai/code/session_014LEh37ASYpUJqvkqYQ5Ni5