### PR TITLE
feat: persist review_flow at registration and register poster as its own type

### DIFF
--- a/scripts/audit-branch-protection.sh
+++ b/scripts/audit-branch-protection.sh
@@ -22,7 +22,7 @@
 #                  smkwlab/student-repo-management）
 #
 # 監査対象:
-#   - repository_type が sotsuron / master / ise のエントリ（保護必須種別）
+#   - review_flow が true のエントリ（draft PR サイクル運用 = ブランチ保護必須）
 #   - archived リポジトリは対象外（過年度分の恒常的なノイズを防ぐ）
 #
 # 分類:
@@ -60,13 +60,13 @@ log "レジストリを取得中: ${REGISTRY_REPO}"
 registry=$(gh api "repos/${REGISTRY_REPO}/contents/data/registry.json" \
     --jq '.content | @base64d')
 
-# 保護必須種別（sotsuron / master / ise）のみ監査対象
+# review_flow が true（draft PR サイクル運用 = 保護必須）のみ監査対象
 mapfile -t repos < <(echo "$registry" | jq -r '
     to_entries[]
-    | select(.value.repository_type as $t | ["sotsuron", "master", "ise"] | index($t))
+    | select(.value.review_flow == true)
     | .key')
 
-log "監査対象: ${#repos[@]} リポジトリ（保護必須種別のみ）"
+log "監査対象: ${#repos[@]} リポジトリ（review_flow 有効のみ）"
 
 checked=0
 skipped_archived=0

--- a/scripts/process-pending-issues.sh
+++ b/scripts/process-pending-issues.sh
@@ -1094,6 +1094,8 @@ execute_issue_processing() {
             fi
             ;;
         latex|other)
+            # other は「ブランチ保護なしで登録のみ」という処理内容が latex
+            # （レビューフロー無効時）と同一のため、latex 経路を共用する
             echo "→ 汎用LaTeX/その他リポジトリの登録処理を実行中..."
             if run_latex_with_feedback; then
                 echo "✅ 処理が完了しました"
@@ -2075,11 +2077,15 @@ update_thesis_student_registry() {
 
     # review_flow: draft PR サイクルで運用するリポジトリか（registry の必須フィールド）。
     # sotsuron / master / ise / poster は常時 true、latex は作成時オプトイン
-    # （CURRENT_REVIEW_FLOW）、wr / other は false
+    # （CURRENT_REVIEW_FLOW）、wr / other は false。
+    # ise-report はこの script の判定では生成されないが registry 語彙の別表記
+    # （validation が受理する）ため、語彙との整合のため含める。
+    # heredoc に JSON boolean として展開するため、リテラルの true 以外はすべて
+    # false に正規化する（値の混入で JSON が壊れるのを防ぐ）。
     local review_flow
     case "$repo_type" in
         sotsuron|master|ise|ise-report|poster) review_flow=true ;;
-        latex) review_flow="${CURRENT_REVIEW_FLOW:-false}" ;;
+        latex) if [ "$CURRENT_REVIEW_FLOW" = true ]; then review_flow=true; else review_flow=false; fi ;;
         *) review_flow=false ;;
     esac
     

--- a/scripts/process-pending-issues.sh
+++ b/scripts/process-pending-issues.sh
@@ -536,9 +536,8 @@ extract_issue_info() {
     # 一度もマッチせず、常に名前パターン以降のフォールバックへ落ちていた）
     if [[ "$CURRENT_ISSUE_BODY" =~ リポジトリタイプ[*[:space:]]*:[[:space:]]*([a-zA-Z0-9]+) ]]; then
         CURRENT_REPO_TYPE="${BASH_REMATCH[1]}"
-        # 旧語彙・別表記を registry の正式語彙へ正規化（issue #471）
-        # poster は処理経路の分岐（ブランチ保護あり）に使うためここでは変換せず、
-        # registry への登録時に "other" へ変換する（registry の語彙に poster はない）
+        # 旧語彙・別表記を registry の正式語彙へ正規化（issue #471）。
+        # poster は registry の正式語彙のためそのまま登録する
         case "$CURRENT_REPO_TYPE" in
             shuuron|thesis) CURRENT_REPO_TYPE="master" ;;
         esac
@@ -582,12 +581,12 @@ extract_issue_info() {
     # 旧パターン4（学生 ID からの推測 rs→sotsuron / gjk→thesis）は誤分類の
     # 主因だったため廃止（issue #471）。卒論・修論は命名規約 *-sotsuron /
     # *-master（防御的別名 *-thesis）で必ずパターン3までに判定される
-    # パターン5: その他のパターンは latex と推測
-    # latex タイプは様々な命名規則のリポジトリに対応するため、
-    # 明示的なタイプ情報がない場合は LaTeX リポジトリとして扱う
+    # パターン5: 明示的なタイプ情報がない未知パターンは other として登録する
+    # （registry-manager の推論 fallback と同一。latex / poster は Issue 本文の
+    # 明示指定でのみ判定し、名前からの推測はしない）
     elif [[ "$CURRENT_REPO_NAME" =~ -[a-zA-Z0-9_-]+$ && ! "$CURRENT_REPO_NAME" == *"-latex" ]]; then
-        CURRENT_REPO_TYPE="latex"
-        log_debug "Issue #${CURRENT_ISSUE_NUMBER}: 未知パターンをlatexタイプとして推測: $CURRENT_REPO_NAME"
+        CURRENT_REPO_TYPE="other"
+        log_debug "Issue #${CURRENT_ISSUE_NUMBER}: 未知パターンを other として登録: $CURRENT_REPO_NAME"
     else
         CURRENT_REPO_TYPE="unknown"
         log_error "Issue #${CURRENT_ISSUE_NUMBER}: リポジトリタイプを判定できませんでした"
@@ -1094,8 +1093,8 @@ execute_issue_processing() {
                 return 1
             fi
             ;;
-        latex)
-            echo "→ 汎用LaTeXリポジトリの登録処理を実行中..."
+        latex|other)
+            echo "→ 汎用LaTeX/その他リポジトリの登録処理を実行中..."
             if run_latex_with_feedback; then
                 echo "✅ 処理が完了しました"
             else
@@ -1503,7 +1502,6 @@ process_ise_with_feedback() {
 # 学会ポスターリポジトリ処理（詳細フィードバック付き）
 #
 # draft PR サイクル（poster-template）を使うためブランチ保護を設定する。
-# registry の repository_type 語彙に poster はないため "other" で登録する。
 #
 process_poster_with_feedback() {
     echo "  📊 学会ポスターリポジトリの処理を開始..."
@@ -1520,7 +1518,7 @@ process_poster_with_feedback() {
 
     # 2. thesis-student-registry 更新
     echo "  thesis-student-registry への登録中..."
-    if update_thesis_student_registry "$CURRENT_REPO_NAME" "$CURRENT_STUDENT_ID" "other"; then
+    if update_thesis_student_registry "$CURRENT_REPO_NAME" "$CURRENT_STUDENT_ID" "$CURRENT_REPO_TYPE"; then
         echo "  ✅ thesis-student-registry への登録完了"
     else
         echo "  ❌ thesis-student-registry への登録失敗"
@@ -1884,13 +1882,12 @@ Pull Requestベースの学習を開始してください。"; then
 # 学会ポスターリポジトリ処理
 #
 # draft PR サイクル（poster-template）を使うためブランチ保護を設定する。
-# registry の repository_type 語彙に poster はないため "other" で登録する。
 #
 process_poster_issue() {
     log_info "学会ポスターリポジトリ処理: $CURRENT_REPO_NAME"
 
     # 1. thesis-student-registry への登録
-    if ! update_thesis_student_registry "$CURRENT_REPO_NAME" "$CURRENT_STUDENT_ID" "other"; then
+    if ! update_thesis_student_registry "$CURRENT_REPO_NAME" "$CURRENT_STUDENT_ID" "$CURRENT_REPO_TYPE"; then
         log_error "thesis-student-registry への登録に失敗: $CURRENT_REPO_NAME"
         return 1
     fi
@@ -2075,6 +2072,16 @@ update_thesis_student_registry() {
     
     # Issue作成者のGitHub usernameを取得
     local github_username="${CURRENT_ISSUE_AUTHOR:-unknown}"
+
+    # review_flow: draft PR サイクルで運用するリポジトリか（registry の必須フィールド）。
+    # sotsuron / master / ise / poster は常時 true、latex は作成時オプトイン
+    # （CURRENT_REVIEW_FLOW）、wr / other は false
+    local review_flow
+    case "$repo_type" in
+        sotsuron|master|ise|ise-report|poster) review_flow=true ;;
+        latex) review_flow="${CURRENT_REVIEW_FLOW:-false}" ;;
+        *) review_flow=false ;;
+    esac
     
     # GET-mutate-PUT を SHA競合(409)に備えてリトライする（Bug #496: 並行 PUT で
     # 登録が失われる）。競合時は最新の content+sha を取り直し mutation を再適用して再 PUT。
@@ -2136,6 +2143,7 @@ update_thesis_student_registry() {
   "repository_type": "$repo_type",
   "created_at": "$created_at",
   "registry_updated_at": "$registry_updated_at",
+  "review_flow": $review_flow,
   "github_username": $github_username_array
 }
 EOF


### PR DESCRIPTION
## 概要

type/review_flow 分離(smkwlab/registry-manager#66)への登録自動化側の追随。registry 側の語彙追加と既存データ backfill(smkwlab/thesis-student-registry#132)は完了済み。

Resolves #547

## 変更内容

- **`review_flow` の書き込み**: 登録エントリに必須フィールド `review_flow` を追加(sotsuron / master / ise / poster → true 固定、latex → Issue 本文から抽出済みの `CURRENT_REVIEW_FLOW`、wr / other → false)
- **poster を `poster` として登録**: registry 語彙に poster が入ったため、`other` への変換を廃止(2 経路とも `$CURRENT_REPO_TYPE` を透過)
- **未知パターンの `latex` 推測を廃止**: registry-manager の推論 fallback と同じ `other` に統一(poster を latex と誤推定した実績への対処)。対話モードのディスパッチも `latex|other)` に拡張し、自動モード(既存の `latex|other)`)と挙動を揃えた
- **audit-branch-protection.sh**: 監査対象の抽出を type ∈ {sotsuron, master, ise} から `review_flow == true` に変更。poster とオプトイン latex が監査対象に入る

## 検証

- `bash -n` 両スクリプト pass
- 登録エントリの heredoc をローカル再現: latex + REVIEW_FLOW=on で `"review_flow": true` の有効な JSON を生成
- audit の jq 抽出を backfill 済み実データ相当で再現: 対象 11 件(ise のみ)→ 13 件(ise 11 + poster 2)に変化

https://claude.ai/code/session_014LEh37ASYpUJqvkqYQ5Ni5