### PR TITLE
feat: show the author README in student repositories

### DIFF
--- a/create-repo/README.md
+++ b/create-repo/README.md
@@ -105,7 +105,7 @@ DEBUG=1 bash <(curl -fsSL https://repo-setup.smkwlab.net) thesis
 5. Pull Request を作成・提出
 6. レビューフィードバックを確認・対応
 
-詳細な手順: [ise-report-template のREADME](https://github.com/smkwlab/ise-report-template/blob/main/README.md) を参照
+詳細な手順: [ise-report-template のREADME](https://github.com/smkwlab/ise-report-template/blob/main/.github/README.md) を参照
 
 ## 各リポジトリの特徴
 

--- a/create-repo/common-lib.sh
+++ b/create-repo/common-lib.sh
@@ -696,6 +696,8 @@ setup_latex_environment() {
 # - CLAUDE.md      : テンプレート／latex-environment 由来の開発者向け説明（学生リポジトリには不要）
 # - docs/          : テンプレート／latex-environment 由来のドキュメント
 # - *-aldc         : aldc が統合時に生成する衝突ファイルのバックアップ
+# - .github/README.md : テンプレートの使い方説明（学生リポジトリでは root の
+#                       著者情報 README をトップに出すために削除する）
 #
 # 重要: この関数は aldc 実行（setup_latex_environment）の **後** に呼ぶ必要があります。
 # aldc は latex-environment 由来の CLAUDE.md / docs/ を持ち込み、既存ファイルと衝突した
@@ -713,6 +715,12 @@ cleanup_template_files() {
     # で管理）。誤マージ防止 CI（prevent-draft-merge）や review 必須保護と dependabot PR
     # が干渉して溜まるため、生成時に削除する（#514）。
     rm -f .github/dependabot.yml 2>/dev/null || true
+    # GitHub は README を .github/ → root → docs/ の順に探して最初の 1 つを表示する。
+    # テンプレート側はこの性質を使い、テンプレートの使い方を .github/README.md に、
+    # 学生が記入する著者情報を root の README.md に置いている。ここで前者を削除する
+    # ことで、学生リポジトリのトップに著者情報 README が表示される
+    # （smkwlab/latex-ecosystem#140）。
+    rm -f .github/README.md 2>/dev/null || true
     return 0
 }
 

--- a/create-repo/main.sh
+++ b/create-repo/main.sh
@@ -432,32 +432,43 @@ print_next_steps() {
     case "$DOC_TYPE" in
         wr)
             print_completion_message "次のステップ:
-1. テンプレートファイル (20yy-mm-dd.tex) をコピーして、日付に基づいたファイル名 (例: 2024-04-01.tex) に変更後、編集
-2. git add, commit, pushで変更を保存
-3. 毎週新しい週報ファイルを追加"
+1. README.md に著者情報（氏名・学籍番号・研究テーマ）を記入
+2. テンプレートファイル (20yy-mm-dd.tex) をコピーして、日付に基づいたファイル名 (例: 2024-04-01.tex) に変更後、編集
+3. git add, commit, pushで変更を保存
+4. 毎週新しい週報ファイルを追加
+
+📖 詳細な手順: テンプレートの README をご確認ください
+  https://github.com/$TEMPLATE_REPOSITORY/blob/main/.github/README.md"
             ;;
         latex)
             if [ "$USE_DRAFT_FLOW" = true ]; then
                 print_completion_message "次のステップ:
-1. 0th-draft ブランチで main.tex を編集して文書を作成
-2. git add, commit, pushで変更を保存
-3. Pull Request を作成して添削を依頼（次稿ブランチは自動作成されます）
-4. GitHub Actionsで自動的にPDFが生成されます
+1. 0th-draft ブランチで README.md に著者情報（氏名・学籍番号・文書のタイトル）を記入
+2. main.tex を編集して文書を作成
+3. git add, commit, pushで変更を保存
+4. Pull Request を作成して添削を依頼（次稿ブランチは自動作成されます）
+5. GitHub Actionsで自動的にPDFが生成されます
 
-📖 詳細な手順: リポジトリの README.md の「添削を受ける場合」をご確認ください"
+📖 詳細な手順: テンプレートの README の「添削を受ける場合」をご確認ください
+  https://github.com/$TEMPLATE_REPOSITORY/blob/main/.github/README.md"
             else
                 print_completion_message "次のステップ:
-1. main.texを編集して文書を作成
-2. git add, commit, pushで変更を保存
-3. GitHub Actionsで自動的にPDFが生成されます"
+1. README.md に著者情報（氏名・学籍番号・文書のタイトル）を記入
+2. main.texを編集して文書を作成
+3. git add, commit, pushで変更を保存
+4. GitHub Actionsで自動的にPDFが生成されます
+
+📖 詳細な手順: テンプレートの README をご確認ください
+  https://github.com/$TEMPLATE_REPOSITORY/blob/main/.github/README.md"
             fi
             ;;
         poster)
             print_completion_message "次のステップ:
-1. 0th-draft ブランチで a0poster.tex を編集してポスターを作成
-2. git add, commit, pushで変更を保存
-3. Pull Request を作成して添削を依頼（次稿ブランチは自動作成されます）
-4. GitHub Actionsで自動的にPDFが生成されます
+1. 0th-draft ブランチで README.md に著者情報（氏名・学籍番号・ポスターのタイトル・発表先）を記入
+2. a0poster.tex を編集してポスターを作成
+3. git add, commit, pushで変更を保存
+4. Pull Request を作成して添削を依頼（次稿ブランチは自動作成されます）
+5. GitHub Actionsで自動的にPDFが生成されます
 
 ポスターテンプレートの特徴:
 - A0サイズ学会ポスター用
@@ -465,22 +476,27 @@ print_next_steps() {
 - LuaLaTeXで日本語完全対応
 - Pull Request ベースの添削フロー（draft サイクル）
 
-📖 詳細な手順: リポジトリの README.md をご確認ください"
+📖 詳細な手順: テンプレートの README をご確認ください
+  https://github.com/$TEMPLATE_REPOSITORY/blob/main/.github/README.md"
             ;;
         thesis)
-            print_completion_message "論文執筆の開始方法:
+            print_completion_message "まず 0th-draft ブランチで README.md に著者情報（氏名・学籍番号・論文タイトル）を記入してください。
+
+論文執筆の開始方法:
   https://github.com/$REPO_PATH/blob/main/WRITING-GUIDE.md"
             ;;
         ise)
             print_completion_message "Pull Request学習を開始してください：
   1. GitHub Desktop または VS Code でリポジトリを開く
-  2. 作業用ブランチ（1st-draft など）を作成
-  3. index.html を編集してレポート作成
-  4. 変更をコミット・プッシュ
-  5. Pull Request を作成して提出
-  6. レビューフィードバックを確認・対応
+  2. README.md に著者情報（氏名・学籍番号・レポートの題目）を記入
+  3. 作業用ブランチ（1st-draft など）を作成
+  4. index.html を編集してレポート作成
+  5. 変更をコミット・プッシュ
+  6. Pull Request を作成して提出
+  7. レビューフィードバックを確認・対応
 
-📖 詳細な手順: リポジトリの README.md をご確認ください"
+📖 詳細な手順: テンプレートの README をご確認ください
+  https://github.com/$TEMPLATE_REPOSITORY/blob/main/.github/README.md"
             ;;
         *)
             die "内部エラー: print_next_steps が未知の DOC_TYPE を受け取りました: $DOC_TYPE"

--- a/create-repo/main.sh
+++ b/create-repo/main.sh
@@ -483,7 +483,10 @@ print_next_steps() {
             print_completion_message "まず 0th-draft ブランチで README.md に著者情報（氏名・学籍番号・論文タイトル）を記入してください。
 
 論文執筆の開始方法:
-  https://github.com/$REPO_PATH/blob/main/WRITING-GUIDE.md"
+  https://github.com/$REPO_PATH/blob/main/WRITING-GUIDE.md
+
+📖 詳細な手順: テンプレートの README をご確認ください
+  https://github.com/$TEMPLATE_REPOSITORY/blob/main/.github/README.md"
             ;;
         ise)
             print_completion_message "Pull Request学習を開始してください：

--- a/create-repo/main.sh
+++ b/create-repo/main.sh
@@ -437,7 +437,7 @@ print_next_steps() {
 3. git add, commit, pushで変更を保存
 4. 毎週新しい週報ファイルを追加
 
-📖 詳細な手順: テンプレートの README をご確認ください
+📖 詳細な手順（テンプレートの README）:
   https://github.com/$TEMPLATE_REPOSITORY/blob/main/.github/README.md"
             ;;
         latex)
@@ -449,7 +449,7 @@ print_next_steps() {
 4. Pull Request を作成して添削を依頼（次稿ブランチは自動作成されます）
 5. GitHub Actionsで自動的にPDFが生成されます
 
-📖 詳細な手順: テンプレートの README の「添削を受ける場合」をご確認ください
+📖 詳細な手順（テンプレートの README「添削を受ける場合」）:
   https://github.com/$TEMPLATE_REPOSITORY/blob/main/.github/README.md"
             else
                 print_completion_message "次のステップ:
@@ -458,7 +458,7 @@ print_next_steps() {
 3. git add, commit, pushで変更を保存
 4. GitHub Actionsで自動的にPDFが生成されます
 
-📖 詳細な手順: テンプレートの README をご確認ください
+📖 詳細な手順（テンプレートの README）:
   https://github.com/$TEMPLATE_REPOSITORY/blob/main/.github/README.md"
             fi
             ;;
@@ -476,7 +476,7 @@ print_next_steps() {
 - LuaLaTeXで日本語完全対応
 - Pull Request ベースの添削フロー（draft サイクル）
 
-📖 詳細な手順: テンプレートの README をご確認ください
+📖 詳細な手順（テンプレートの README）:
   https://github.com/$TEMPLATE_REPOSITORY/blob/main/.github/README.md"
             ;;
         thesis)
@@ -485,7 +485,7 @@ print_next_steps() {
 論文執筆の開始方法:
   https://github.com/$REPO_PATH/blob/main/WRITING-GUIDE.md
 
-📖 詳細な手順: テンプレートの README をご確認ください
+📖 詳細な手順（テンプレートの README）:
   https://github.com/$TEMPLATE_REPOSITORY/blob/main/.github/README.md"
             ;;
         ise)
@@ -498,7 +498,7 @@ print_next_steps() {
   6. Pull Request を作成して提出
   7. レビューフィードバックを確認・対応
 
-📖 詳細な手順: テンプレートの README をご確認ください
+📖 詳細な手順（テンプレートの README）:
   https://github.com/$TEMPLATE_REPOSITORY/blob/main/.github/README.md"
             ;;
         *)


### PR DESCRIPTION
## 概要

リポジトリ作成時に `.github/README.md` を削除し、学生リポジトリのトップに著者情報 README を表示させます。

Resolves #550
親 Issue: smkwlab/latex-ecosystem#140

## 背景

各テンプレートはテンプレート説明を `.github/README.md` へ移し、root `README.md` を学生が記入する著者情報にしました（sotsuron#139 / wr#56 / ise-report#91 / latex#49 / poster#27、すべて merge 済み）。

GitHub は README を `.github/` → root → `docs/` の順に探して最初の 1 つを表示します。テンプレートリポジトリではテンプレート説明が表示され、**作成時に `.github/README.md` を削除することで学生リポジトリでは著者情報 README が表示されます。**

## 変更内容

### `cleanup_template_files()`（`create-repo/common-lib.sh`）

`.github/dependabot.yml` を削除している既存処理と同じ形で 1 行追加しました。`docs/` の削除など他の処理は変更していません。

```bash
rm -f .github/dependabot.yml 2>/dev/null || true
rm -f .github/README.md 2>/dev/null || true
```

### 完了メッセージ（`create-repo/main.sh`）

「📖 詳細な手順: リポジトリの README.md をご確認ください」という案内が 3 箇所ありましたが、**学生リポジトリの `README.md` は著者情報になったため、案内したい内容がそこにありません。** テンプレートの README を URL で示すよう変更しました。

URL は `$TEMPLATE_REPOSITORY` を使うため、他 org 運用でも追従します（`TEMPLATE_REPO` による上書きも反映されます）。

あわせて、**著者情報の記入を「次のステップ」の最初に置きました**。プレースホルダは作成時に埋めず学生自身が書き換える方針のため、最初の作業として案内する必要があります（thesis / wr / latex / poster / ise の全タイプ）。

### `create-repo/README.md`

ise-report-template の README への URL を `.github/README.md` に追随させました。

## 検証

実リポジトリの作成は副作用（registry 登録・Issue 作成・org へのリポジトリ追加）が大きいため、`cleanup_template_files()` を 5 テンプレートの実際のツリー（`git archive HEAD` で展開）に対して単体実行して確認しました。

| テンプレート | `README.md` | `.github/README.md` | `docs/` | `CLAUDE.md` |
|---|---|---|---|---|
| sotsuron-template | 残 | 削除 | 削除 | 削除 |
| wr-template | 残 | 削除 | 削除 | 削除 |
| ise-report-template | 残 | 削除 | 削除 | 削除 |
| latex-template | 残 | 削除 | 削除 | 削除 |
| poster-template | 残 | 削除 | 削除 | 削除 |

残った `README.md` の 1 行目もすべて著者情報のひな形でした（`# （氏名）卒業論文 / 修士論文` など）。

`bash -n` による構文チェックも通っています（shellcheck の警告は既存箇所のみで、本 PR の変更とは無関係）。

実際のリポジトリ作成による end-to-end 検証が必要であれば、テスト用リポジトリを作成して確認します。削除に `delete_repo` スコープが必要なため、実施可否を確認したうえで行います。

## 対象外

`sotsuron-report-template` は現在「Use this template」で使わせており `DOC_TYPE`（`thesis` / `wr` / `latex` / `ise` / `poster`）に含まれないため、`cleanup_template_files()` 自体が走りません。適用は create-repo への `sotsuron-report` タイプ追加とセットで別途判断します。
