### PR TITLE
ci: deploy Pages on manual dispatch only

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -9,15 +9,15 @@
 # EMBEDDED_REF="v1.x.y", so the template content it clones is pinned to that
 # same release -- serving main would silently unpin both halves.
 #
-# Deploys when a release tag is pushed. The run that matters is the v1 move in
-# step 7 of docs/RELEASE.md; a vX.Y.Z push earlier in that procedure also fires
-# but still publishes whatever v1 points at, so the final state is correct
-# either way. Use workflow_dispatch to redeploy without a release.
+# Runs on manual dispatch only, as the last step of docs/RELEASE.md. Tag pushes
+# used to trigger it, but the github-pages environment allows deployments from
+# the main branch only, so every tag-triggered run failed at the deploy job
+# (#552) -- two failures per release, which trains everyone to ignore them.
+# Dispatching from main is safe: the checkout below pins v1 regardless of what
+# ref the run started on.
 name: Deploy setup.sh to Pages
 
 on:
-  push:
-    tags: ['v*']
   workflow_dispatch:
 
 concurrency:

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -78,7 +78,11 @@ git tag -f v1 v1.0.0^{}
 git push origin v1 --force
 
 # 8. 短縮 URL へ配信する（手動実行。自動では走らない）
+#    デプロイ完了まで数十秒〜数分かかる。完了を待たずに手順 9 を実行すると
+#    古い配信内容を見て「反映されていない」と誤判断するため、必ず待つこと
 gh workflow run "Deploy setup.sh to Pages" --ref main
+sleep 10  # run が Actions に登録されるまでの待ち
+gh run watch "$(gh run list -w 'Deploy setup.sh to Pages' -L 1 --json databaseId --jq '.[0].databaseId')"
 
 # 9. 配信内容が新しいリリースに入れ替わったことを確かめる（必須）
 #    ここまでやって初めて学生の実行経路に反映される。手順 8 を忘れても

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -77,9 +77,13 @@ gh release create v1.0.0 --title "v1.0.0" --notes "リリース内容..."
 git tag -f v1 v1.0.0^{}
 git push origin v1 --force
 
-# 8. 短縮 URL の再デプロイを確認（v1 の push で自動実行される）
-#    配信内容が新しいリリースに入れ替わったことを確かめる
-curl -fsSL https://repo-setup.smkwlab.net | grep EMBEDDED_REF
+# 8. 短縮 URL へ配信する（手動実行。自動では走らない）
+gh workflow run "Deploy setup.sh to Pages" --ref main
+
+# 9. 配信内容が新しいリリースに入れ替わったことを確かめる（必須）
+#    ここまでやって初めて学生の実行経路に反映される。手順 8 を忘れても
+#    リリース自体は成功して見えるため、この確認が唯一の検出手段になる
+curl -fsSL https://repo-setup.smkwlab.net | grep '^EMBEDDED_REF='
 ```
 
 > **重要**: リリース用コミット（`EMBEDDED_REF="v1.0.0"`）を `main` にマージしないこと。
@@ -88,14 +92,21 @@ curl -fsSL https://repo-setup.smkwlab.net | grep EMBEDDED_REF
 
 ### 短縮 URL への反映
 
-短縮 URL `https://repo-setup.smkwlab.net` は `v1` の `setup.sh` を配信しており
-（[`.github/workflows/pages.yml`](../.github/workflows/pages.yml)）、手順 7 の
-`v1` push で自動的に再デプロイされる。`main` への push では**再デプロイされない**
-（学生が未リリースの変更を踏まないようにするため）。
+短縮 URL `https://repo-setup.smkwlab.net` は `v1` の `setup.sh` を配信する
+（[`.github/workflows/pages.yml`](../.github/workflows/pages.yml)）。
 
-反映されない場合は Actions から `Deploy setup.sh to Pages` を `workflow_dispatch`
-で手動実行する。workflow は配信前に `EMBEDDED_REF` を検証し、`main` を配信しよう
-とした場合は失敗する。
+**配信は自動では走らない。** タグや `main` への push では再デプロイされず、
+`workflow_dispatch` による手動実行だけがトリガとなる（手順 8）。Actions の画面から
+`Deploy setup.sh to Pages` を実行してもよい。
+
+手動のみである理由は、`github-pages` environment の deployment branch policy が
+`main` ブランチのみを許可しているため。`v1` は `--force` で動かすタグであり、
+学生が `curl | bash` で実行するスクリプトの配信元をタグ操作で差し替えられないよう、
+この保護は維持する（#552）。
+
+`main` から実行しても `main` の `setup.sh` が配信されることはない。workflow は
+`ref: v1` を固定でチェックアウトし、さらに配信前に `EMBEDDED_REF` を検証して
+`main` であれば失敗する。
 
 ## メジャー移動タグ（`v1` など）
 

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -78,16 +78,17 @@ git tag -f v1 v1.0.0^{}
 git push origin v1 --force
 
 # 8. 短縮 URL へ配信する（手動実行。自動では走らない）
-#    デプロイ完了まで数十秒〜数分かかる。完了を待たずに手順 9 を実行すると
-#    古い配信内容を見て「反映されていない」と誤判断するため、必ず待つこと
 gh workflow run "Deploy setup.sh to Pages" --ref main
-sleep 10  # run が Actions に登録されるまでの待ち
-gh run watch "$(gh run list -w 'Deploy setup.sh to Pages' -L 1 --json databaseId --jq '.[0].databaseId')"
 
 # 9. 配信内容が新しいリリースに入れ替わったことを確かめる（必須）
 #    ここまでやって初めて学生の実行経路に反映される。手順 8 を忘れても
-#    リリース自体は成功して見えるため、この確認が唯一の検出手段になる
-curl -fsSL https://repo-setup.smkwlab.net | grep '^EMBEDDED_REF='
+#    リリース自体は成功して見えるため、この確認が唯一の検出手段になる。
+#    デプロイ完了まで数十秒〜数分かかるので、タグ名が出るまで待つ
+until curl -fsSL https://repo-setup.smkwlab.net | grep -q '^EMBEDDED_REF="v1.0.0"'; do
+    sleep 10
+done
+# 待っても変わらない場合は Actions で "Deploy setup.sh to Pages" の失敗を確認する
+gh run list -w "Deploy setup.sh to Pages" -L 3
 ```
 
 > **重要**: リリース用コミット（`EMBEDDED_REF="v1.0.0"`）を `main` にマージしないこと。

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -83,11 +83,14 @@ gh workflow run "Deploy setup.sh to Pages" --ref main
 # 9. 配信内容が新しいリリースに入れ替わったことを確かめる（必須）
 #    ここまでやって初めて学生の実行経路に反映される。手順 8 を忘れても
 #    リリース自体は成功して見えるため、この確認が唯一の検出手段になる。
-#    デプロイ完了まで数十秒〜数分かかるので、タグ名が出るまで待つ
-until curl -fsSL https://repo-setup.smkwlab.net | grep -q '^EMBEDDED_REF="v1.0.0"'; do
+#    デプロイ完了まで数十秒〜数分かかるので、タグ名が出るまで待つ（最大 5 分）
+for _ in $(seq 30); do
+    curl -fsSL https://repo-setup.smkwlab.net | grep -q '^EMBEDDED_REF="v1.0.0"' && break
     sleep 10
 done
-# 待っても変わらない場合は Actions で "Deploy setup.sh to Pages" の失敗を確認する
+curl -fsSL https://repo-setup.smkwlab.net | grep '^EMBEDDED_REF='
+
+# 表示されたタグが今回のリリースでなければ、デプロイが失敗している
 gh run list -w "Deploy setup.sh to Pages" -L 3
 ```
 


### PR DESCRIPTION
## 概要

Pages デプロイのトリガをタグ push から `workflow_dispatch` のみに変え、`docs/RELEASE.md` を実態に合わせます。

Resolves #552

## 背景

`github-pages` environment の deployment branch policy は `main` ブランチのみを許可しています。そのため**タグ起動の run は必ず deploy ジョブで失敗**します。

```
Tag "v1" is not allowed to deploy to github-pages due to environment protection rules.
```

v1.4.0 のリリースで `v1.4.0` と `v1` の push により 2 件の run が起動し、いずれも失敗しました（`Build Pages artifact` は success、`Deploy to GitHub Pages` が failure）。過去に成功しているデプロイもすべて `main` からの `workflow_dispatch` で、タグ起動で成功した実績はありません。

にもかかわらず `docs/RELEASE.md` は「`v1` の push で自動的に再デプロイされる」と記述していたため、**v1.4.0 はリリース後も短縮 URL に反映されないまま**でした（手動 dispatch で復旧済み）。

## 変更内容

### `.github/workflows/pages.yml`

```yaml
on:
  workflow_dispatch:
```

`push: tags: ['v*']` を削除しました。冒頭コメントにも、タグ起動が environment の保護ルールで失敗すること、`main` からの dispatch が安全である理由（`ref: v1` 固定）を記載しています。

### `docs/RELEASE.md`

- 手順 8 を `gh workflow run "Deploy setup.sh to Pages" --ref main` に変更
- **手順 9（`curl` による配信確認）を必須と明記**。手順 8 を忘れてもリリース自体は成功して見えるため、この確認が唯一の検出手段になります
- 「短縮 URL への反映」節から「`v1` push で自動的に再デプロイされる」という記述を削除し、手動のみである事実とその理由を記載

## environment にタグを許可する案を採らなかった理由

1. **配信元の保護粒度が落ちる。** `v1` は運用上 `--force` で動かすタグです。タグからのデプロイを許すと、タグを書き換えられる人が配信内容を差し替えられる経路ができます。配信物は学生が `curl | bash` で実行するスクリプトなので、`main` の branch protection に守られた状態を維持したいと考えました
2. **設定が Git 管理外になる。** environment 設定は repo 設定であり、他 org 展開時に再現手順が増えます
3. **1 リリースで 2 回デプロイが走る。** `vX.Y.Z` の push でも起動しますが、その時点で `v1` はまだ前のリリースを指しているため古い内容を配信します。最終状態は正しいものの、一瞬古い版が配信される窓ができます

## 安全性

手動起動にしても、誤って `main` の内容が配信される危険は増えません。workflow には二重の安全装置があります。

- `ref: v1` を固定でチェックアウトするため、`main` から dispatch しても `main` の `setup.sh` は配信されない
- `Verify the artifact is a release, not main` ステップが `EMBEDDED_REF` を検証し、`main` なら失敗する

## 検証

`./scripts/validate-yaml.sh` が pass しています（yamllint / actionlint とも）。残っている warning は既存行のもので、本 PR の変更箇所ではありません。

トリガ変更の実地確認は、次回リリース時または任意のタイミングで `gh workflow run "Deploy setup.sh to Pages" --ref main` を実行して行えます（v1.4.0 のデプロイでこの経路が動作することは確認済みです）。
