### PR TITLE
feat: add the sotsuron-report document type

### DIFF
--- a/.github/workflows/yaml-validation.yml
+++ b/.github/workflows/yaml-validation.yml
@@ -42,6 +42,11 @@ jobs:
           # Run actionlint with warnings allowed for initial setup
           actionlint -ignore 'SC2129:.*' -ignore '.*potentially untrusted.*' || true
 
+      - name: Validate type confs
+        run: |
+          echo "Validating create-repo/types/*.conf against the contract..."
+          ./scripts/validate-type-confs.sh
+
       - name: Validation summary
         run: |
           echo "✅ All YAML files passed validation!"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,6 +18,7 @@ bash <(curl -fsSL https://repo-setup.smkwlab.net) wr       # Weekly reports
 bash <(curl -fsSL https://repo-setup.smkwlab.net) latex    # General LaTeX
 bash <(curl -fsSL https://repo-setup.smkwlab.net) ise      # ISE reports
 bash <(curl -fsSL https://repo-setup.smkwlab.net) poster   # Conference posters
+bash <(curl -fsSL https://repo-setup.smkwlab.net) sotsuron-report  # Thesis survey reports
 
 # Environment variable style (Legacy, still supported)
 DOC_TYPE=thesis bash <(curl -fsSL https://repo-setup.smkwlab.net)
@@ -66,14 +67,14 @@ For manual branch protection setup or troubleshooting:
 gh repo view smkwlab/k21rs001-sotsuron --json branchProtectionRules
 ```
 
-**Note**: Weekly reports (wr-template) do not use branch protection as they have simpler workflows. General LaTeX documents (latex-template) do not use it by default either, but opt in via `REVIEW_FLOW=true` at creation time. ISE reports (ise-report-template) and posters (poster-template) always use the same PR-based branch protection as thesis repositories.
+**Note**: Weekly reports (wr-template) and thesis survey reports (sotsuron-report-template) do not use branch protection as they have simpler workflows. General LaTeX documents (latex-template) do not use it by default either, but opt in via `REVIEW_FLOW=true` at creation time. ISE reports (ise-report-template) and posters (poster-template) always use the same PR-based branch protection as thesis repositories.
 
 ## Key Files & Structure
 
 ```
 create-repo/
 ├── setup.sh              # Universal Setup Script - All document types
-├── main.sh               # Unified creation script (DOC_TYPE: thesis/wr/latex/ise/poster)
+├── main.sh               # Unified creation script (DOC_TYPE: thesis/wr/latex/ise/poster/sotsuron-report)
 ├── common-lib.sh         # Shared functions and utilities
 ├── types/                # Per-type definitions (static config + repo-name/commit/completion functions); see types/README.md
 └── Dockerfile            # Docker image shared by all document types
@@ -108,13 +109,14 @@ Universal Setup Script uses `DOC_TYPE` environment variable to specify document 
 - **latex**: General LaTeX documents (latex-template)
 - **ise**: Information Science Exercise reports (ise-report-template)
 - **poster**: Conference posters (poster-template)
+- **sotsuron-report**: Thesis survey reports (sotsuron-report-template)
 
 ### Environment Variable Options
 ```bash
 # LaTeX document configuration
 DOCUMENT_NAME=research-note    # Custom document name
 
-# Draft PR review flow opt-in (DOC_TYPE=latex only; thesis/ise/poster are always on, wr unsupported)
+# Draft PR review flow opt-in (DOC_TYPE=latex only; thesis/ise/poster are always on, wr and sotsuron-report unsupported)
 REVIEW_FLOW=true               # Initialize main + 0th-draft, enable auto-assign, apply branch protection
 
 # Individual mode behavior (DOC_TYPE=latex only)

--- a/create-repo/main.sh
+++ b/create-repo/main.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 # 学生リポジトリセットアップスクリプト（統合版）
 #
-# 5 種類の文書タイプ（thesis / wr / latex / ise / poster）のリポジトリ作成を
+# 6 種類の文書タイプ（thesis / wr / latex / ise / poster / sotsuron-report）の
+# リポジトリ作成を
 # 1 本で担う。タイプは環境変数 DOC_TYPE で選択する（setup.sh が
 # docker run -e DOC_TYPE=... で注入。位置引数 $1 は従来どおり学籍番号）。
 #
@@ -30,7 +31,7 @@ source ./common-lib.sh
 # setup.sh 側の case でも whitelist 済みだが、コンテナを setup.sh 経由せず
 # 直接実行するデバッグ経路でも安全にするため二重に検証する
 # （AUTO_ASSIGN_REVIEWER の二重検証と同じ既存流儀）。
-DOC_TYPE="${DOC_TYPE:?DOC_TYPE を指定してください (thesis|wr|latex|ise|poster)}"
+DOC_TYPE="${DOC_TYPE:?DOC_TYPE を指定してください (thesis|wr|latex|ise|poster|sotsuron-report)}"
 
 # ================================
 # タイプ定義の読み込み
@@ -44,8 +45,9 @@ case "$DOC_TYPE" in
     latex)  source ./types/latex.conf ;;
     ise)    source ./types/ise.conf ;;
     poster) source ./types/poster.conf ;;
+    sotsuron-report) source ./types/sotsuron-report.conf ;;
     *)
-        die "サポートされていない文書タイプ: $DOC_TYPE (thesis|wr|latex|ise|poster)"
+        die "サポートされていない文書タイプ: $DOC_TYPE (thesis|wr|latex|ise|poster|sotsuron-report)"
         ;;
 esac
 

--- a/create-repo/setup.sh
+++ b/create-repo/setup.sh
@@ -163,7 +163,7 @@ configure_document_type() {
             ;;
         *)
             echo "❌ サポートされていない文書タイプ: $doc_type"
-            echo "対応タイプ: thesis, wr, latex, ise, poster"
+            echo "対応タイプ: thesis, wr, latex, ise, poster, sotsuron-report"
             exit 1
             ;;
     esac

--- a/create-repo/setup.sh
+++ b/create-repo/setup.sh
@@ -113,6 +113,7 @@ if [ -z "$DOC_TYPE" ]; then
     echo "  /bin/bash -c \"\$(curl -fsSL https://raw.githubusercontent.com/${TOOLS_REPO_OWNER}/${TOOLS_REPO}/main/create-repo/setup.sh)\" bash latex"
     echo "  /bin/bash -c \"\$(curl -fsSL https://raw.githubusercontent.com/${TOOLS_REPO_OWNER}/${TOOLS_REPO}/main/create-repo/setup.sh)\" bash ise"
     echo "  /bin/bash -c \"\$(curl -fsSL https://raw.githubusercontent.com/${TOOLS_REPO_OWNER}/${TOOLS_REPO}/main/create-repo/setup.sh)\" bash poster"
+    echo "  /bin/bash -c \"\$(curl -fsSL https://raw.githubusercontent.com/${TOOLS_REPO_OWNER}/${TOOLS_REPO}/main/create-repo/setup.sh)\" bash sotsuron-report"
     echo ""
     echo "学籍番号を指定する場合（環境変数）："
     echo "  STUDENT_ID=k21rs001 /bin/bash -c \"\$(curl -fsSL https://raw.githubusercontent.com/${TOOLS_REPO_OWNER}/${TOOLS_REPO}/main/create-repo/setup.sh)\" bash thesis"
@@ -128,7 +129,7 @@ DETECTED_DOC_TYPE="$DOC_TYPE"
 
 # 設定マッピング
 # この case は DOC_TYPE の whitelist 検証を兼ねる（後段で -e DOC_TYPE として
-# 無引用のまま docker run へ渡すため、ここを通過した 5 値以外は流れない）。
+# 無引用のまま docker run へ渡すため、ここを通過した 6 値以外は流れない）。
 # Dockerfile / 実行スクリプトはタイプ共通（create-repo/Dockerfile + main.sh、
 # タイプは DOC_TYPE 環境変数で選択。Issue #516）。旧構成の ref を指定した
 # 場合のフォールバックは clone 後に判定する。
@@ -155,6 +156,10 @@ configure_document_type() {
         poster)
             DOC_DESCRIPTION="📊 学会ポスターリポジトリ"
             DOCKER_IMAGE_NAME="poster-setup-alpine"
+            ;;
+        sotsuron-report)
+            DOC_DESCRIPTION="📝 卒業論文調査報告リポジトリ"
+            DOCKER_IMAGE_NAME="sotsuron-report-setup-alpine"
             ;;
         *)
             echo "❌ サポートされていない文書タイプ: $doc_type"

--- a/create-repo/types/sotsuron-report.conf
+++ b/create-repo/types/sotsuron-report.conf
@@ -1,0 +1,49 @@
+# shellcheck shell=bash
+# shellcheck disable=SC2034  # 変数は source 元の main.sh が参照する
+# タイプ定義: sotsuron-report（卒業論文調査報告）
+# main.sh の明示 whitelist case から source される。定義してよいのは
+# 決められた変数と決められた関数名のみ（types/README.md 参照）。
+# 文言（プロンプト・コミットメッセージ・完了メッセージ）は学生リポジトリの
+# 履歴・実行ログに残るため逐語保存。1 文字も変えないこと。
+
+SCRIPT_TITLE="卒業論文調査報告リポジトリセットアップツール"
+SCRIPT_EMOJI="📝"
+STUDENT_ID_EXAMPLES=""
+RUN_ALDC=true
+SETUP_AUTO_ASSIGN=false
+USE_DRAFT_FLOW=false
+
+# テンプレートの既定値: org 追従（他 org では ${ORGANIZATION}/sotsuron-report-template）
+TEMPLATE_BASENAME="sotsuron-report-template"
+TEMPLATE_ORG_POLICY="follow"
+
+# 設定される変数: REPO_NAME
+decide_repo_name() {
+    if is_individual_mode; then
+        REPO_NAME="sotsuron-report"
+    else
+        REPO_NAME="${STUDENT_ID}-sotsuron-report"
+    fi
+}
+
+build_commit_message() {
+    if is_individual_mode; then
+        COMMIT_MESSAGE="Initialize sotsuron-report repository
+
+- Setup LaTeX environment for thesis survey reports
+"
+    else
+        COMMIT_MESSAGE="Initialize sotsuron-report repository for ${STUDENT_ID}
+
+- Setup LaTeX environment for thesis survey reports
+"
+    fi
+}
+
+print_next_steps() {
+    print_completion_message "次のステップ:
+1. README.md に著者情報（氏名・学籍番号・研究テーマ）を記入
+2. テンプレートファイル (sotsuron-report.tex) を報告日の名前でコピー (例: 2026-05-11.tex) して編集
+3. git add, commit, pushで変更を保存
+4. 報告のたびに新しいファイルを追加"
+}

--- a/docs/CLAUDE-DEVELOPMENT.md
+++ b/docs/CLAUDE-DEVELOPMENT.md
@@ -55,7 +55,7 @@ variables (defaults preserve smkwlab behavior):
 | `TOOLS_REPO_OWNER` | `$DEFAULT_ORG` | Owner of the `student-repo-management` repo cloned internally. Distinct from `TARGET_ORG` (which may be a personal account). |
 | `TOOLS_REPO_NAME` | `student-repo-management` | Repo name cloned internally and forwarded to the container for registry integration. |
 | `TOOLS_CLONE_URL` | `https://github.com/<owner>/<repo>.git` | Full override of the clone URL (e.g. GitHub Enterprise / mirror). Must start with `https://` or `git@`. When set alone, also set `TOOLS_REPO_OWNER`/`TOOLS_REPO_NAME` so the usage/releases URLs in help text match the actual clone source. |
-| `TEMPLATE_REPO` | per doc type | Source template repo. `thesis`/`ise`/`wr` default to `<org>/…`; `latex`/`poster` default to `smkwlab/…` (shared templates used by individual accounts too). Set to `<org>/<template>` to use your own. |
+| `TEMPLATE_REPO` | per doc type | Source template repo. `thesis`/`ise`/`wr`/`sotsuron-report` default to `<org>/…`; `latex`/`poster` default to `smkwlab/…` (shared templates used by individual accounts too). Set to `<org>/<template>` to use your own. |
 | `AUTO_ASSIGN_REVIEWER` | `toshi0806` | GitHub login inserted as the reviewer/assignee in the auto-assign config injected into organization-member repos. Set to a member of your org, or auto-assign will not work. |
 | `ALDC_URL` | `https://raw.githubusercontent.com/smkwlab/aldc/main/aldc` | Source of the aldc LaTeX-devcontainer installer fetched during setup. Must start with `https://`. |
 | `SETUP_GIT_EMAIL_DOMAIN` | `smkwlab.github.io` | Domain for the `setup-*@…` commit-author email used by the container. |
@@ -107,7 +107,7 @@ Sophisticated GitHub Actions-based supervision:
 ```
 create-repo/
 ├── setup.sh                    # Universal entry point (all document types)
-├── main.sh                     # Unified creation script (DOC_TYPE: thesis/wr/latex/ise/poster)
+├── main.sh                     # Unified creation script (DOC_TYPE: thesis/wr/latex/ise/poster/sotsuron-report)
 ├── common-lib.sh               # Shared functions and utilities
 ├── types/                      # Per-type definitions (static config + repo-name/commit/completion functions); see types/README.md
 ├── Dockerfile                  # Docker image shared by all document types

--- a/scripts/validate-type-confs.sh
+++ b/scripts/validate-type-confs.sh
@@ -24,12 +24,15 @@ for conf in "${TYPES_DIR}"/*.conf; do
     name=$(basename "$conf")
     # clean な bash で source し、宣言差分と TEMPLATE_ORG_POLICY を出力させる。
     # env -i で親環境を遮断する（共通変数の「新規定義」を確実に差分に出すため）
-    out=$(env -i bash --noprofile --norc -c '
+    # 内側シェルの死（構文エラー・set -u の未定義参照など）は per-conf の NG に
+    # 変換し、後続 conf の検査を続ける（|| で受けないと外側の set -e が全体を止め、
+    # 診断が出ないまま残りが未検査になる）
+    if ! out=$(env -i bash --noprofile --norc -c '
         set -u
         conf="$1"
         # スナップショット用の自前変数は差分から除外する
         before_vars=$(compgen -v | sort)
-        source "$conf"
+        source "$conf" || exit 3
         after_vars=$(compgen -v | sort)
         # comm -13 は「source で新規定義された名前」だけを検出する（既存名の
         # unset は対象外。clean シェルのため保護すべき既存名は元々ほぼ無い）
@@ -41,7 +44,11 @@ for conf in "${TYPES_DIR}"/*.conf; do
         echo "VARS:$(echo $new_vars)"
         echo "FUNCS:$(echo $new_funcs)"
         echo "POLICY:${TEMPLATE_ORG_POLICY:-<unset>}"
-    ' _ "$conf")
+    ' _ "$conf"); then
+        echo "NG  $name: source に失敗しました（構文エラーまたは実行時エラー）"
+        fail=1
+        continue
+    fi
     vars=$(sed -n 's/^VARS://p' <<<"$out")
     funcs=$(sed -n 's/^FUNCS://p' <<<"$out")
     policy=$(sed -n 's/^POLICY://p' <<<"$out")

--- a/scripts/validate-type-confs.sh
+++ b/scripts/validate-type-confs.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+#
+# validate-type-confs.sh
+#
+# create-repo/types/*.conf が契約（create-repo/types/README.md）を守っている
+# ことを機械検証する。各 conf を clean な bash で source し、定義された変数・
+# 関数が契約の一覧と**完全一致**することを確認する:
+# - 契約外の名前を定義していない（ORGANIZATION 等の共通変数の誤上書き検出）
+# - 契約の名前をすべて定義している（必須 3 関数・必須変数の欠落検出）
+# - TEMPLATE_ORG_POLICY が follow / smkwlab のいずれかである
+#
+# main.sh は関与しない（source 時点の宣言だけを見る静的な契約検査。文言の
+# 逐語保存はレビューで担保する）。
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TYPES_DIR="${REPO_ROOT}/create-repo/types"
+
+ALLOWED_VARS="RUN_ALDC SCRIPT_EMOJI SCRIPT_TITLE SETUP_AUTO_ASSIGN STUDENT_ID_EXAMPLES TEMPLATE_BASENAME TEMPLATE_ORG_POLICY USE_DRAFT_FLOW"
+ALLOWED_FUNCS="build_commit_message decide_repo_name print_next_steps"
+
+fail=0
+for conf in "${TYPES_DIR}"/*.conf; do
+    name=$(basename "$conf")
+    # clean な bash で source し、宣言差分と TEMPLATE_ORG_POLICY を出力させる。
+    # env -i で親環境を遮断する（共通変数の「新規定義」を確実に差分に出すため）
+    out=$(env -i bash --noprofile --norc -c '
+        set -u
+        conf="$1"
+        # スナップショット用の自前変数は差分から除外する
+        before_vars=$(compgen -v | sort)
+        source "$conf"
+        after_vars=$(compgen -v | sort)
+        new_vars=$(comm -13 <(printf "%s\n" "$before_vars") <(printf "%s\n" "$after_vars") \
+                   | grep -v -x -e before_vars -e after_vars || true)
+        new_funcs=$(declare -F | awk "{print \$3}" | sort)
+        echo "VARS:$(echo $new_vars)"
+        echo "FUNCS:$(echo $new_funcs)"
+        echo "POLICY:${TEMPLATE_ORG_POLICY:-<unset>}"
+    ' _ "$conf")
+    vars=$(sed -n 's/^VARS://p' <<<"$out")
+    funcs=$(sed -n 's/^FUNCS://p' <<<"$out")
+    policy=$(sed -n 's/^POLICY://p' <<<"$out")
+
+    err=""
+    [ "$vars" = "$ALLOWED_VARS" ] || err+=" 変数が契約と不一致: [$vars]"
+    [ "$funcs" = "$ALLOWED_FUNCS" ] || err+=" 関数が契約と不一致: [$funcs]"
+    case "$policy" in follow|smkwlab) ;; *) err+=" TEMPLATE_ORG_POLICY が不正: $policy" ;; esac
+
+    if [ -z "$err" ]; then
+        echo "OK  $name"
+    else
+        echo "NG  $name:$err"
+        fail=1
+    fi
+done
+
+if [ "$fail" -ne 0 ]; then
+    echo "❌ types conf の契約違反があります（create-repo/types/README.md 参照）" >&2
+    exit 1
+fi
+echo "✅ all type confs conform to the contract"

--- a/scripts/validate-type-confs.sh
+++ b/scripts/validate-type-confs.sh
@@ -31,9 +31,13 @@ for conf in "${TYPES_DIR}"/*.conf; do
         before_vars=$(compgen -v | sort)
         source "$conf"
         after_vars=$(compgen -v | sort)
+        # comm -13 は「source で新規定義された名前」だけを検出する（既存名の
+        # unset は対象外。clean シェルのため保護すべき既存名は元々ほぼ無い）
         new_vars=$(comm -13 <(printf "%s\n" "$before_vars") <(printf "%s\n" "$after_vars") \
                    | grep -v -x -e before_vars -e after_vars || true)
         new_funcs=$(declare -F | awk "{print \$3}" | sort)
+        # $(echo $var) のクォート無しは意図的: 改行区切りをスペース区切り 1 行に
+        # 正規化して ALLOWED_* と比較する（順序は直前の sort が保証）
         echo "VARS:$(echo $new_vars)"
         echo "FUNCS:$(echo $new_funcs)"
         echo "POLICY:${TEMPLATE_ORG_POLICY:-<unset>}"


### PR DESCRIPTION
## 概要

`DOC_TYPE=sotsuron-report`（卒業論文調査報告）を追加します。#556 の conf 方式の**最初の適用例**で、実装は `types/sotsuron-report.conf` 1 枚 + whitelist 各 1 行が主体です。

Resolves #555
親 Issue: smkwlab/latex-ecosystem#144 ／ 依存: smkwlab/registry-manager#69（語彙追加）

## タイプ設定（Issue で確定済み）

| 項目 | 値 | 根拠 |
|---|---|---|
| リポジトリ名 | `<学籍番号>-sotsuron-report` | |
| draft PR サイクル | **なし**（`USE_DRAFT_FLOW=false` / `SETUP_AUTO_ASSIGN=false`） | 報告日ごとに tex をコピーして書く wr 型の文書 |
| `RUN_ALDC` | true | LaTeX 系 |
| テンプレート既定 | org 追従（`${ORGANIZATION}/sotsuron-report-template`） | thesis / wr / ise と同グループ |
| registry | type `sotsuron-report` で登録 | 語彙追加は registry-manager#69 で先行 |

完了メッセージは wr の流儀に合わせつつ、`sotsuron-report.tex` を報告日名でコピーする運用を案内します。テンプレート README への 📖 リンクは付けていません（このテンプレートは `.github/README.md` を持たない、srt#31 参照）。

## 変更ファイル

- `create-repo/types/sotsuron-report.conf`（新規）
- `create-repo/main.sh` — whitelist 1 行 + タイプ列挙メッセージ（5 種類 → 6 種類）
- `create-repo/setup.sh` — `configure_document_type` の case・usage 例・ヘッダコメント
- `CLAUDE.md` / `docs/CLAUDE-DEVELOPMENT.md` — タイプ列挙の追随

## conf 契約の CI テスト（#556 レビュー提案の導入）

`scripts/validate-type-confs.sh` を追加し、`yaml-validation` workflow に組み込みました。各 conf を `env -i` の clean シェルで source し、**宣言された変数・関数が契約（`types/README.md`）と完全一致**することを検証します。

- 共通変数（`ORGANIZATION` 等）の誤上書き → 契約外の変数として検出
- 必須 3 関数の欠落 → 不一致として検出
- どちらの違反クラスも、壊した conf を一時的に置く negative test で検出できることを確認済み

全 6 conf pass。

## 検証

- 契約テスト・`validate-yaml.sh`・`bash -n`・shellcheck すべて pass
- 新 conf の 3 関数をスタブ実行し、REPO_NAME（通常/個人）・コミットメッセージ・完了メッセージの出力を確認

**end-to-end（実リポジトリ作成）は未実施**です。registry 登録は RM#69 の語彙追加前は warn で続行される設計のため、merge 後にテストリポジトリで検証可能ですが、実施は別途指示を仰ぎます。

## リリース順序

本 PR の merge は先行できますが、**学生経路への配信（v1.5.0）は registry-manager#69 の merge 後**とします。後続作業（srt#31 の保留解除・リリース・latex-ecosystem docs の追随）は #555 に記録済みです。
