### PR TITLE
fix: process sotsuron-report registrations as their own type

### DIFF
--- a/scripts/process-pending-issues.sh
+++ b/scripts/process-pending-issues.sh
@@ -196,8 +196,8 @@ parse_options() {
                 ;;
             --type)
                 FILTER_TYPE="$2"
-                if [[ ! "$FILTER_TYPE" =~ ^(wr|sotsuron|thesis|ise|latex)$ ]]; then
-                    log_error "無効なタイプ: $FILTER_TYPE (有効: wr, sotsuron, thesis, ise, latex)"
+                if [[ ! "$FILTER_TYPE" =~ ^(wr|sotsuron|thesis|ise|latex|sotsuron-report)$ ]]; then
+                    log_error "無効なタイプ: $FILTER_TYPE (有効: wr, sotsuron, thesis, ise, latex, sotsuron-report)"
                     exit 1
                 fi
                 shift 2
@@ -443,10 +443,14 @@ fetch_pending_issues() {
                 issues_json=$(echo "$issues_json" | jq '[.[] | select(.title | contains("-latex"))]')
                 ;;
             sotsuron)
-                issues_json=$(echo "$issues_json" | jq '[.[] | select(.title | contains("-sotsuron"))]')
+                # -sotsuron-report を巻き込まないよう除外する（#559）
+                issues_json=$(echo "$issues_json" | jq '[.[] | select((.title | contains("-sotsuron")) and (.title | contains("-sotsuron-report") | not))]')
                 ;;
             thesis)
                 issues_json=$(echo "$issues_json" | jq '[.[] | select(.title | contains("-thesis"))]')
+                ;;
+            sotsuron-report)
+                issues_json=$(echo "$issues_json" | jq '[.[] | select(.title | contains("-sotsuron-report"))]')
                 ;;
         esac
     fi
@@ -534,7 +538,9 @@ extract_issue_info() {
     # generate_issue_body の実出力は「**リポジトリタイプ**: <type>」で、ラベル直後に
     # Markdown の ** が挟まるため [*[:space:]]* で許容する（従来の [[:space:]]* のみでは
     # 一度もマッチせず、常に名前パターン以降のフォールバックへ落ちていた）
-    if [[ "$CURRENT_ISSUE_BODY" =~ リポジトリタイプ[*[:space:]]*:[[:space:]]*([a-zA-Z0-9]+) ]]; then
+    # 文字クラスの - は必須: sotsuron-report のようなハイフン入りタイプを
+    # 途中で切ると（例: sotsuron）、誤った保護適用・review_flow に波及する（#559）
+    if [[ "$CURRENT_ISSUE_BODY" =~ リポジトリタイプ[*[:space:]]*:[[:space:]]*([a-zA-Z0-9-]+) ]]; then
         CURRENT_REPO_TYPE="${BASH_REMATCH[1]}"
         # 旧語彙・別表記を registry の正式語彙へ正規化（issue #471）。
         # poster は registry の正式語彙のためそのまま登録する
@@ -975,6 +981,9 @@ show_issue_summary() {
             ;;
         poster)
             echo "  種別: 学会ポスターリポジトリ"
+            ;;
+        sotsuron-report)
+            echo "  種別: 卒業論文調査報告リポジトリ"
             ;;
         *)
             echo "  種別: 不明 (${CURRENT_REPO_TYPE})"
@@ -1742,8 +1751,9 @@ process_single_issue() {
         poster)
             process_poster_issue
             ;;
-        latex|other)
-            # latex はレビューフロー有効時のみブランチ保護付きの処理に分岐する
+        latex|other|sotsuron-report)
+            # latex はレビューフロー有効時のみブランチ保護付きの処理に分岐する。
+            # other / sotsuron-report は常に登録のみ（保護なし・review_flow=false）
             if [ "$CURRENT_REPO_TYPE" = "latex" ] && [ "$CURRENT_REVIEW_FLOW" = true ]; then
                 process_latex_review_issue
             else
@@ -1973,10 +1983,11 @@ process_latex_review_issue() {
     return 0
 }
 
-# LaTeXリポジトリ処理
+# 登録のみリポジトリ処理
 #
-# latex と other の両タイプを処理する（どちらもブランチ保護なし・registry 登録
-# + Issue クローズのみ。登録タイプは解決済みの CURRENT_REPO_TYPE を使用）
+# latex / other / sotsuron-report を処理する（いずれもブランチ保護なし・
+# registry 登録 + Issue クローズのみ。登録タイプは解決済みの
+# CURRENT_REPO_TYPE を使用）
 process_latex_issue() {
     log_info "LaTeXリポジトリ処理: $CURRENT_REPO_NAME"
     
@@ -1987,13 +1998,13 @@ process_latex_issue() {
     fi
     
     # 2. Issue クローズ
-    if ! close_issue_with_comment "$CURRENT_ISSUE_NUMBER" "✅ LaTeXリポジトリの登録が完了しました
+    if ! close_issue_with_comment "$CURRENT_ISSUE_NUMBER" "✅ リポジトリの登録が完了しました
 
 ## 処理内容
 - **リポジトリ登録**: [${DEPLOY_ORG}/$CURRENT_REPO_NAME](https://github.com/${DEPLOY_ORG}/$CURRENT_REPO_NAME) ✓
 - **設定日時**: $(date '+%Y-%m-%d %H:%M:%S JST')
 
-## 汎用LaTeXリポジトリについて
+## このリポジトリについて
 - mainブランチで直接作業が可能です
 - Pull Requestベースのレビューは任意です
 - 自動PDF生成機能が利用可能です
@@ -2077,7 +2088,7 @@ update_thesis_student_registry() {
 
     # review_flow: draft PR サイクルで運用するリポジトリか（registry の必須フィールド）。
     # sotsuron / master / ise / poster は常時 true、latex は作成時オプトイン
-    # （CURRENT_REVIEW_FLOW）、wr / other は false。
+    # （CURRENT_REVIEW_FLOW）、wr / other / sotsuron-report は false。
     # ise-report はこの script の判定では生成されないが registry 語彙の別表記
     # （validation が受理する）ため、語彙との整合のため含める。
     # heredoc に JSON boolean として展開するため、リテラルの true 以外はすべて


### PR DESCRIPTION
## 概要

`DOC_TYPE=sotsuron-report` の end-to-end 検証で発覚した登録自動処理の誤動作（#559）を修正します。**v1.5.0 リリースのブロッカー**です。

Resolves #559
関連: #557（タイプ追加）/ smkwlab/registry-manager#70（RM 側の同種修正）／ 親: smkwlab/latex-ecosystem#144

## 実測された誤動作

テストリポジトリ `k99rs999-sotsuron-report` の登録 Issue #558（本文には正しく `**リポジトリタイプ**: sotsuron-report` と明示）の処理結果:

```json
"repository_type": "sotsuron",   ← 誤（卒業論文扱い）
"review_flow": true              ← 誤
```

さらにブランチ保護（required_pull_request_reviews）まで誤適用。

## 修正内容

### 1. 明示タイプ抽出の regex にハイフンを追加

文字クラス `[a-zA-Z0-9]+` が `sotsuron-report` を途中で切り、`sotsuron` を「明示されたタイプ」として返していました。**実 Issue #558 の本文で検証済み**: 旧 regex → `sotsuron`、新 regex → `sotsuron-report`。既存 7 タイプの抽出は不変。

### 2. `process_single_issue` に処理経路を追加

regex 修正だけだと `*)` に落ちて「不明なリポジトリタイプ」で **return 1** になります。`latex|other` と同じ登録のみ経路（保護なし・review_flow=false）に `sotsuron-report` を追加しました。あわせて、この経路のクローズコメントが全リポジトリを「LaTeXリポジトリ」と呼んでいた文言を type 中立に改めました。

### 3. `--type` フィルタの追随

- `sotsuron-report` をフィルタ語彙と title フィルタに追加
- 既存の `--type sotsuron` フィルタが `contains("-sotsuron")` の部分一致で `-sotsuron-report` を**巻き込んでいた**問題を除外条件で修正（jq のパイプ文脈バグを踏んだため、フィクスチャで動作検証済み）

### 4. 表示・コメントの追随

種別表示に「卒業論文調査報告リポジトリ」を追加、review_flow 既定のコメントに sotsuron-report を明記。

## 検証

- 実 Issue #558 本文での抽出検証（新旧 regex 比較 + 既存 7 タイプの不変確認）
- jq フィルタのフィクスチャ検証（sotsuron が sotsuron-report を除外、sotsuron-report が自分だけ取る）
- `bash -n` / `./scripts/validate-yaml.sh` pass

## merge 後の作業（#559 に記録）

テスト成果物の掃除（registry の誤エントリ削除・誤適用保護の解除・テストリポジトリ削除）→ end-to-end 再実行で `sotsuron-report` / `review_flow: false` / 保護なしを確認 → v1.5.0 リリースへ。
