### PR TITLE
docs: point sotsuron-report completions at the template README

### DIFF
--- a/create-repo/types/sotsuron-report.conf
+++ b/create-repo/types/sotsuron-report.conf
@@ -45,5 +45,8 @@ print_next_steps() {
 1. README.md に著者情報（氏名・学籍番号・研究テーマ）を記入
 2. テンプレートファイル (sotsuron-report.tex) を報告日の名前でコピー (例: 2026-05-11.tex) して編集
 3. git add, commit, pushで変更を保存
-4. 報告のたびに新しいファイルを追加"
+4. 報告のたびに新しいファイルを追加
+
+📖 詳細な手順（テンプレートの README）:
+  https://github.com/$TEMPLATE_REPOSITORY/blob/main/.github/README.md"
 }


### PR DESCRIPTION
## 概要

`sotsuron-report` の完了メッセージに、他の全タイプが持つテンプレート README への 📖 案内ブロックを追加します。

関連: smkwlab/sotsuron-report-template#31 の訂正コメント（派生する修正候補 2）

## 背景

conf 作成時（#557）、「sotsuron-report-template は `.github/README.md` を持たない」という誤認に基づいて案内ブロックを省いていました。実際には最初から存在し、smkwlab/sotsuron-report-template#33 でワンライナー入りに全面更新済みのため、省いた前提が消えています。

## 変更

`types/sotsuron-report.conf` の `print_next_steps` に 2 行追加（他タイプと同一の形式・`$TEMPLATE_REPOSITORY` 参照で org 追従）。

## 検証

- conf 契約テスト（`validate-type-confs.sh`）pass
- スタブ実行で出力確認（`https://github.com/smkwlab/sotsuron-report-template/blob/main/.github/README.md` が展開される）

## リリース

学生に届くのはリリース後のため、merge 後に v1.5.1（PATCH）としてリリースします。
