### PR TITLE
chore: stop tracking Claude Code local settings

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,8 +1,0 @@
-{
-  "permissions": {
-    "allow": [
-      "Bash(find:*)"
-    ],
-    "deny": []
-  }
-}

--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,6 @@ data/
 # Script execution logs (development and runtime logs)
 logs/
 backups/
+
+# Claude Code local settings (per-machine, not shared)
+.claude/settings.local.json


### PR DESCRIPTION
## 概要

`.claude/settings.local.json` は Claude Code がマシンごとに書き出すローカル設定だが、`135c742` でコミットされ追跡対象になっていた。`.gitignore` にも記載が無かった。追跡を解除し、除外する。

## 変更内容

- `git rm --cached .claude/settings.local.json`（追跡解除。ファイルはディスク上に残る）
- `.gitignore` に `.claude/settings.local.json` を追加

追跡されていた内容:

```json
{
  "permissions": {
    "allow": ["Bash(find:*)"],
    "deny": []
  }
}
```

## 影響

既存の clone ではファイルがディスクに残るため、作業への影響は無い。新規 clone では生成されなくなるが、Claude Code が起動時にマシンごとの設定を書き出すため問題ない。

`.claude/` 配下のそれ以外（skill、チームで共有する `settings.json` 等）は引き続き追跡できる。

## 背景

エコシステム内で `.claude` の扱いが 3 方式に分かれていたため、多数派（`settings.local.json` のみ除外）に揃える取り組みの一環。関連 PR:

- smkwlab/ecosystem-manager#8
- smkwlab/registry-manager#71
