### PR TITLE
fix(renovate): return the preset reference to the moving v1 tag

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,4 +1,4 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["github>smkwlab/.github:latex#v1.26.0"]
+  "extends": ["github>smkwlab/.github:latex#v1"]
 }


### PR DESCRIPTION
## 概要

共有 Renovate preset の参照を `github>smkwlab/.github:latex#v1.26.0` から `#v1`（移動タグ）へ戻す。

```diff
-  "extends": ["github>smkwlab/.github:latex#v1.26.0"]
+  "extends": ["github>smkwlab/.github:latex#v1"]
```

## なぜ

このリポジトリは元々 `:latex#v1` で導入されていた（`eefa5dc` "Use shared Renovate preset (github>smkwlab/.github:latex#v1)"）。その後 Renovate の `renovate-config` manager が preset 参照自体を依存関係として扱い、固定タグへ書き換える PR を出し続けた結果、移動タグから外れていた。

| commit | 変更 | 作者 |
|---|---|---|
| `eefa5dc` | 導入時: `:latex#v1` | 人 |
| `9861551` | `#v1` → `#v1.23.0` | renovate[bot] |
| `8176e1d` | `#v1.23.0` → `#v1.24.0` | renovate[bot] |
| `0e82857` | `#v1.24.0` → `#v1.26.0` | renovate[bot] |

誰も pin する判断をしていない。`CONTRIBUTING.md` にも「再利用ワークフローや共有設定は `@v1`（タグ）参照」と明記されており、latex 系の他 4 リポジトリはすべて `#v1` のまま。このリポジトリだけが方針から外れている状態だった。

実害として、smkwlab/.github#112（Renovate のキュー滞留解消）が固定タグ参照のこのリポジトリにだけ届かなかった。

## 依存関係と merge 順序

再書き換えを防ぐガード（`renovate-config` manager の無効化）を smkwlab/.github#113 で入れる。

1. smkwlab/.github#113 を merge
2. `v1.28.0` タグと移動タグ `v1` を更新
3. **その後で**本 PR を merge

この順序を守らないと、ガードが `v1` に乗る前に Renovate が再び固定タグへ書き戻す。
