### PR TITLE
feat(scripts): remove dependabot.yml left in student repositories

### DIFF
--- a/scripts/remove-dependabot-config.sh
+++ b/scripts/remove-dependabot-config.sh
@@ -87,8 +87,15 @@ repos=$(gh repo list "$ORG" --limit "$REPO_LIST_LIMIT" --json name,isArchived \
     --jq ".[] | select(.name | test(\"${REPO_PATTERN}\")) | \"\(.name)\t\(.isArchived)\"" \
     | sort)
 
-total=$(printf '%s\n' "$repos" | grep -c . || true)
+total=$(printf '%s\n' "$repos" | awk 'NF {n++} END {print n+0}')
 log "学生リポジトリ: ${total} 件を走査"
+
+# 0 件は「学生リポジトリが無い」より「パターンか取得上限が壊れている」可能性の
+# 方が高い。黙って何もせず正常終了すると、削除できたと誤解されるので止める
+if [ "$total" -eq 0 ]; then
+    log "走査対象が 0 件。REPO_PATTERN と REPO_LIST_LIMIT を確認すること"
+    exit 1
+fi
 
 while IFS=$'\t' read -r name archived; do
     [ -z "$name" ] && continue
@@ -104,6 +111,10 @@ while IFS=$'\t' read -r name archived; do
         continue
     fi
 
+    # archived の判定を sha 取得の後に置いているのは意図的。archived を先に
+    # 弾けば API 呼び出しを節約できるが、それでは「archived な学生リポジトリ
+    # の総数」を数えることになる。知りたいのは「archived かつファイルが残って
+    # いる数」なので、ファイルの有無を確かめてから数える
     if [ "$archived" = "true" ]; then
         skipped_archived=$((skipped_archived + 1))
         log "  skip (archived): ${name}"
@@ -116,7 +127,16 @@ while IFS=$'\t' read -r name archived; do
         continue
     fi
 
-    branch=$(gh api "repos/${ORG}/${name}" --jq '.default_branch')
+    # 取得に失敗しても走査を止めない。set -e の下では branch=$(...) の失敗が
+    # スクリプト全体を落とし、途中まで進んだ結果が読めなくなる
+    if ! branch=$(gh api "repos/${ORG}/${name}" --jq '.default_branch' 2>/dev/null) \
+        || [ -z "$branch" ] || [ "$branch" = "null" ]; then
+        errors=$((errors + 1))
+        error_repos="${error_repos}${name}"$'\n'
+        log "  ERROR: ${name} — default_branch を取得できなかった"
+        continue
+    fi
+
     if gh api -X DELETE "repos/${ORG}/${name}/contents/${TARGET_PATH}" \
         -f "message=${COMMIT_MESSAGE}" \
         -f "sha=${sha}" \
@@ -125,7 +145,7 @@ while IFS=$'\t' read -r name archived; do
         log "  removed: ${name} (${branch})"
     else
         errors=$((errors + 1))
-        error_repos="${error_repos}${name} "
+        error_repos="${error_repos}${name}"$'\n'
         log "  ERROR: ${name} — 削除できなかった（権限・保護設定を確認）"
     fi
 done <<EOF
@@ -140,6 +160,11 @@ else
 fi
 log "スキップ (archived): ${skipped_archived} 件"
 if [ "$errors" -gt 0 ]; then
-    log "エラー: ${errors} 件 — ${error_repos}"
+    log "エラー: ${errors} 件"
+    # 1 行 1 リポジトリで出す。再実行しても contents API の DELETE は
+    # 冪等なので、削除済みのものは 404 になるだけで害はない
+    printf '%s' "$error_repos" | while IFS= read -r r; do
+        [ -n "$r" ] && log "  - ${r}"
+    done
     exit 1
 fi

--- a/scripts/remove-dependabot-config.sh
+++ b/scripts/remove-dependabot-config.sh
@@ -1,0 +1,145 @@
+#!/bin/bash
+#
+# Residual dependabot.yml Removal Script
+#
+# 学生リポジトリに残った .github/dependabot.yml を削除する（issue #574）。
+#
+# 生成時の削除処理は #514（2026-07-11）で入ったが、それ以前に作られた
+# リポジトリには残っている。設定が残っていると Dependabot が PR を作り続け、
+# 誤マージ防止 CI や review 必須保護と干渉して溜まる。学生から見れば、自分が
+# 作った覚えのない PR が論文リポジトリに現れ、承認が必要なため自分では閉じる
+# 以外にできることがない。
+#
+# Usage:
+#   ./remove-dependabot-config.sh            # 対象を列挙するのみ（既定）
+#   ./remove-dependabot-config.sh --apply    # 実際に削除する
+#
+# 既定を dry-run にしているのは、この操作が学生リポジトリの内容を消すため。
+# 同じ scripts/ の audit-branch-protection.sh は --dry-run をオプトインに
+# しているが、そちらは Issue を起票するだけで破壊的ではない。
+#
+# Environment:
+#   ORG              対象 org（default: smkwlab）
+#   REPO_PATTERN     学生リポジトリを識別する正規表現
+#                    （default: ^k[0-9]{2}(rs|gjk)[0-9]+）
+#   REPO_LIST_LIMIT  gh repo list の取得上限（default: 2000）。org の
+#                    リポジトリ総数を下回ると走査対象が黙って欠ける
+#
+# 対象:
+#   - .github/dependabot.yml が存在する学生リポジトリ
+#   - archived は対象外。読み取り専用で Dependabot が動かないため設定が
+#     残っていても新しい PR は作られない。unarchive → 削除 → 再 archive は
+#     得られるものに対して操作が重い
+#
+# 前提:
+#   ブランチ保護は required_approving_review_count=1 だが enforce_admins=false
+#   なので、管理者権限の gh 認証であれば contents API から直接削除できる。
+#   権限が足りない場合は該当リポジトリを errors として報告し、処理は続行する。
+
+set -eu
+
+ORG="${ORG:-smkwlab}"
+# 既定値を ${VAR:-...} に直接書かない。パターンに含まれる {2} の } が
+# パラメータ展開を早期に終わらせ、壊れた正規表現になる
+REPO_PATTERN="${REPO_PATTERN:-}"
+if [ -z "$REPO_PATTERN" ]; then
+    REPO_PATTERN='^k[0-9]{2}(rs|gjk)[0-9]+'
+fi
+# org のリポジトリ総数を上回る値にする（gh は既定 30 件で打ち切る）
+REPO_LIST_LIMIT="${REPO_LIST_LIMIT:-2000}"
+TARGET_PATH=".github/dependabot.yml"
+COMMIT_MESSAGE="chore: remove dependabot.yml inherited from the template
+
+学生リポジトリでは Actions の自動更新は不要（最新化はテンプレート側で管理）。
+誤マージ防止 CI や review 必須保護と dependabot PR が干渉して溜まるため削除する。
+
+Refs smkwlab/student-repo-management#574"
+
+APPLY=false
+if [ "${1:-}" = "--apply" ]; then
+    APPLY=true
+elif [ -n "${1:-}" ]; then
+    echo "不明な引数: $1" >&2
+    echo "Usage: $0 [--apply]" >&2
+    exit 1
+fi
+
+log() {
+    echo "[$(date +'%Y-%m-%d %H:%M:%S')] $1"
+}
+
+removed=0
+skipped_archived=0
+errors=0
+error_repos=""
+
+log "対象 org: ${ORG}"
+if [ "$APPLY" = "true" ]; then
+    log "モード: --apply（実際に削除する）"
+else
+    log "モード: dry-run（列挙のみ。削除するには --apply を付ける）"
+fi
+
+# 学生リポジトリを列挙する。registry ではなくリポジトリ名で判定するのは、
+# 登録依頼 Issue を経由していないリポジトリ（ポスター・研究会論文など）にも
+# 同じ残存があるため。
+repos=$(gh repo list "$ORG" --limit "$REPO_LIST_LIMIT" --json name,isArchived \
+    --jq ".[] | select(.name | test(\"${REPO_PATTERN}\")) | \"\(.name)\t\(.isArchived)\"" \
+    | sort)
+
+total=$(printf '%s\n' "$repos" | grep -c . || true)
+log "学生リポジトリ: ${total} 件を走査"
+
+while IFS=$'\t' read -r name archived; do
+    [ -z "$name" ] && continue
+
+    # ファイルの有無で対象を決める。同時に sha を取る（削除に必要）。
+    # gh api は 404 でもエラー JSON を stdout に出すため、出力の空判定では
+    # なく終了状態で分岐する（|| true で握りつぶすと全リポジトリが対象になる）
+    if ! sha=$(gh api "repos/${ORG}/${name}/contents/${TARGET_PATH}" \
+        --jq '.sha' 2>/dev/null); then
+        continue
+    fi
+    if [ -z "$sha" ] || [ "$sha" = "null" ]; then
+        continue
+    fi
+
+    if [ "$archived" = "true" ]; then
+        skipped_archived=$((skipped_archived + 1))
+        log "  skip (archived): ${name}"
+        continue
+    fi
+
+    if [ "$APPLY" != "true" ]; then
+        log "  target: ${name}"
+        removed=$((removed + 1))
+        continue
+    fi
+
+    branch=$(gh api "repos/${ORG}/${name}" --jq '.default_branch')
+    if gh api -X DELETE "repos/${ORG}/${name}/contents/${TARGET_PATH}" \
+        -f "message=${COMMIT_MESSAGE}" \
+        -f "sha=${sha}" \
+        -f "branch=${branch}" >/dev/null 2>&1; then
+        removed=$((removed + 1))
+        log "  removed: ${name} (${branch})"
+    else
+        errors=$((errors + 1))
+        error_repos="${error_repos}${name} "
+        log "  ERROR: ${name} — 削除できなかった（権限・保護設定を確認）"
+    fi
+done <<EOF
+$repos
+EOF
+
+log "---"
+if [ "$APPLY" = "true" ]; then
+    log "削除: ${removed} 件"
+else
+    log "削除対象: ${removed} 件（--apply で実行）"
+fi
+log "スキップ (archived): ${skipped_archived} 件"
+if [ "$errors" -gt 0 ]; then
+    log "エラー: ${errors} 件 — ${error_repos}"
+    exit 1
+fi

--- a/scripts/remove-dependabot-config.sh
+++ b/scripts/remove-dependabot-config.sh
@@ -166,5 +166,8 @@ if [ "$errors" -gt 0 ]; then
     printf '%s' "$error_repos" | while IFS= read -r r; do
         [ -n "$r" ] && log "  - ${r}"
     done
+    # 全リポジトリを試したうえで、1 件でも失敗があれば非ゼロで終わる。
+    # 「途中で止めない」ことと「失敗を成功として返さない」ことは両立する。
+    # 上の一覧を見て、残ったものだけ再実行すればよい
     exit 1
 fi


### PR DESCRIPTION
## 概要

学生リポジトリに残った `.github/dependabot.yml` を一括削除するスクリプトを追加する。

Resolves #574

**本 PR はスクリプトの追加のみで、リポジトリへの適用は行っていない。** 実際の削除はレビュー後、承認を得てから別途実行する。

## 件数の訂正（2 回誤りました）

| 時点 | 対象件数 | 誤りの原因 |
|---|---|---|
| issue 起票時 | 27 件 | 2026 年作成分のみを調べていた |
| issue コメントでの訂正 | 55 件 | `gh repo list --limit 300` が org の 543 リポジトリを途中で切っていた |
| **本 PR（実測）** | **60 件**（active 22 / archived 38） | — |

走査対象は学生リポジトリ 241 件。数字はスクリプトの dry-run で得たもので、ファイルの無いリポジトリが列挙されないことも反証チェックで確認している。

## 対象は active な 22 件のみ

archived な 38 件は対象外とする。読み取り専用で Dependabot が動かず、実測でも open な dependabot PR は 1 件も無かった。設定が残っていても新しい PR は作られないので、38 リポジトリを unarchive → 削除 → 再 archive する操作に見合わない。

実害が現在進行中のものが 1 件ある。

```
k19rs999-sotsuron
  #13 2026-02-20 Bump kentaro-m/auto-assign-action from 2.0.0 to 2.0.1
  #11 2026-01-01 Bump smkwlab/ai-academic-paper-reviewer from 1.1.0 to 1.3
  #10 2026-01-01 Bump actions/checkout from 4 to 6
```

最古のものは 7 か月間 open のまま。学生から見れば、自分が作った覚えのない PR が現れ、ブランチ保護で承認が必要なため**閉じる以外にできることがない**。

## 設計

**既定を dry-run にした。** 同じ `scripts/` の `audit-branch-protection.sh` は `--dry-run` をオプトインにしているが、そちらは Issue を起票するだけで破壊的ではない。こちらは学生リポジトリの内容を消すので `--apply` をオプトインにしている。

**リポジトリ名で判定する。** registry ではなくリポジトリ名のパターンで学生リポジトリを識別する。登録依頼 Issue を経由していないリポジトリ（ポスター、研究会論文など）にも同じ残存があるため。

**削除は contents API で行う。** ブランチ保護は `required_approving_review_count: 1` だが `enforce_admins: false` なので、管理者権限の認証であれば直接削除できる。失敗したリポジトリは errors として報告し、処理は続行する。

## 検証中に踏んだ罠を 2 つコメントに残した

どちらも実際に踏んで、dry-run の結果がおかしいことから気付いたもの。

**1. パラメータ展開の早期終了**

```bash
REPO_PATTERN="${REPO_PATTERN:-^k[0-9]{2}(rs|gjk)[0-9]+}"
```

`{2}` の `}` が展開を終わらせ、`^k[0-9]{2(rs|gjk)[0-9]+}` という何にもマッチしない正規表現になる。走査結果が 0 件になって発覚した。

**2. `gh api` の 404 が stdout に出る**

```bash
sha=$(gh api "repos/.../contents/..." --jq '.sha' 2>/dev/null || true)
[ -z "$sha" ] && continue
```

404 のときも**エラー JSON が stdout に出て**、失敗は終了状態だけで伝わる。`|| true` で握りつぶすと非空文字列が sha として通り、**全 241 リポジトリが対象になる**。実際に 49 件 + 192 件という辻褄の合わない数字が出て発覚した。終了状態で分岐するよう直した。

## 検証

```
shellcheck  → 指摘なし
bash -n     → OK

dry-run:
  学生リポジトリ: 241 件を走査
  削除対象: 22 件
  スキップ (archived): 38 件

反証チェック:
  k25gjk05-ASD36        ログ内 0 件（ファイル無し、正しく除外）
  k19rs999-ise-report1  ログ内 0 件（同上）
  k19rs999-sotsuron     target として列挙（ファイルあり）
  k24rs023-ise-report1  target として列挙（同上）
```

## 適用時の注意

`--apply` は 22 リポジトリの `main` に直接コミットする。実行前に dry-run で対象を確認すること。archived を含めたい場合は、先に unarchive してから実行する必要がある（スクリプトは archived を無条件でスキップする）。
