### PR TITLE
docs: describe what the final-tag workflow actually does

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,8 +116,7 @@ INDIVIDUAL_MODE=true bash <(curl -fsSL https://repo-setup.smkwlab.net) latex
 
 - **[setup-branch-protection.sh](scripts/setup-branch-protection.sh)**: mainブランチ保護設定（教員用）
   - main ブランチの誤操作防止
-  - GitHub Actions自動マージ許可
-  - final-*タグ時の自動マージ対応
+  - GitHub Actions によるレビュー要件のバイパスを許可
 
 ### `create-repo/` - リポジトリ作成ツール
 

--- a/docs/CLAUDE-WORKFLOWS.md
+++ b/docs/CLAUDE-WORKFLOWS.md
@@ -21,7 +21,7 @@ Phase 2: Abstract Writing
 abstract-1st → abstract-2nd → abstract completion
 
 Phase 3: Final Submission
-Further improvements → Final PR → Faculty approval → final-* tag → Auto-merge
+Further improvements → final-* tag → submission PR opened automatically → faculty merges
 ```
 
 ## Faculty Workflow


### PR DESCRIPTION
## 概要

`final-*` タグを打ったときに何が起きるかの記述を、実装に一致させる。

smkwlab/latex-ecosystem#158 の追随。本体の修正は smkwlab/latex-ecosystem#160。

## 変更内容

**`README.md`（L119-120）** — `setup-branch-protection.sh` の機能説明

```diff
   - main ブランチの誤操作防止
-  - GitHub Actions自動マージ許可
-  - final-*タグ時の自動マージ対応
+  - GitHub Actions によるレビュー要件のバイパスを許可
```

「GitHub Actions自動マージ許可」が指していたのは、同スクリプトが設定する `bypass_pull_request_allowances.apps: ["github-actions"]` である。自動マージの設定ではなくレビュー要件のバイパス許可なので、そう書き直した。「final-*タグ時の自動マージ対応」は該当する動作が存在しないため削除した。

**`docs/CLAUDE-WORKFLOWS.md`（L24）** — フェーズ図

```diff
 Phase 3: Final Submission
-Further improvements → Final PR → Faculty approval → final-* tag → Auto-merge
+Further improvements → final-* tag → submission PR opened automatically → faculty merges
```

自動マージが無くなっただけでなく、**順序も逆だった**。実際はタグが先で、そこから提出 PR が作られる。

## 実装の実態

`auto-final-merge.yml`（ワークフロー名 `Create Final PR to Main`）は、タグの付いた commit を含むブランチから `main` への提出 PR を作成するのみで、マージはしない。commit `64c9f2b` で意図的にそう変更された。

## 補足

`setup-branch-protection.sh` が設定する `bypass_pull_request_allowances` 自体は、**旧実装が実際にマージしていた頃の名残の可能性**がある。現在 `main` へ push する Actions は見当たらない。ブランチ保護の設定変更は記述の修正とは別の話なので、本 PR では触っていない。
