### PR TITLE
fix(scripts): drop the unused bypass allowance and set enforce_admins once

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ INDIVIDUAL_MODE=true bash <(curl -fsSL https://repo-setup.smkwlab.net) latex
 
 - **[setup-branch-protection.sh](scripts/setup-branch-protection.sh)**: mainブランチ保護設定（教員用）
   - main ブランチの誤操作防止
-  - GitHub Actions によるレビュー要件のバイパスを許可
+  - 管理者は保護を回避可能（`enforce_admins: false`。教員の緊急対応用）
 
 ### `create-repo/` - リポジトリ作成ツール
 

--- a/scripts/setup-branch-protection.sh
+++ b/scripts/setup-branch-protection.sh
@@ -130,43 +130,6 @@ verify_admin_permissions() {
     fi
 }
 
-# enforce_admins 設定
-# GitHub API では enforce_admins は別エンドポイントで設定する必要がある
-# 参照: https://docs.github.com/en/rest/branches/branch-protection#set-admin-branch-protection
-setup_enforce_admins() {
-    local owner="$1"
-    local repo_name="$2"
-    local enforce="$3"  # true or false
-    local branch="${4:-main}"  # 将来の拡張用（複数ブランチ対応）
-
-    log "enforce_admins 設定: $enforce (branch: $branch)"
-
-    if [ "$enforce" = "true" ]; then
-        # 管理者にも保護ルールを適用
-        if gh api --method POST \
-           "repos/$owner/$repo_name/branches/$branch/protection/enforce_admins" \
-           >/dev/null 2>&1; then
-            success "✅ enforce_admins: true を設定しました"
-            return 0
-        else
-            warn "⚠️  enforce_admins: true の設定に失敗しました"
-            return 1
-        fi
-    else
-        # 管理者は保護ルールを回避可能（学生リポジトリ向け）
-        if gh api --method DELETE \
-           "repos/$owner/$repo_name/branches/$branch/protection/enforce_admins" \
-           >/dev/null 2>&1; then
-            success "✅ enforce_admins: false を設定しました（管理者は保護ルールを回避可能）"
-            return 0
-        else
-            # DELETE が失敗しても、既に false の場合があるため警告のみ
-            log "enforce_admins: false の設定をスキップ（既に設定済みの可能性）"
-            return 0
-        fi
-    fi
-}
-
 # 学生リストの更新（pending → completed）
 update_student_lists() {
     local repo_name="$1"
@@ -274,14 +237,9 @@ setup_protection() {
             "dismissal_restrictions": {
                 "users": [],
                 "teams": []
-            },
-            "bypass_pull_request_allowances": {
-                "users": [],
-                "teams": [],
-                "apps": ["github-actions"]
             }
         },
-        "enforce_admins": true,
+        "enforce_admins": false,
         "restrictions": null,
         "allow_force_pushes": false,
         "allow_deletions": false
@@ -336,13 +294,7 @@ setup_protection() {
         success "     - Requires 1 approving review before merge"
         success "     - Dismisses stale reviews when new commits are pushed"
         success "     - Prevents force pushes and branch deletion"
-
-        # enforce_admins を false に設定（学生リポジトリでは管理者が直接操作できるようにする）
-        # 注: テンプレートリポジトリでは true を設定すべきだが、このスクリプトは学生リポジトリ用
-        if ! setup_enforce_admins "$owner" "$repo_name" "false"; then
-            error "❌ enforce_admins 設定に失敗しました"
-            return 1
-        fi
+        success "     - Lets administrators bypass protection (enforce_admins: false)"
 
         # 学生リストの更新（pending → completed）
         # 学生レジストリ（thesis-student-registry）は REGISTRY_OWNER 配下の学生

--- a/scripts/setup-branch-protection.sh
+++ b/scripts/setup-branch-protection.sh
@@ -225,6 +225,11 @@ setup_protection() {
     fi
 
     # 各ブランチへの保護設定
+    #
+    # bypass_pull_request_allowances は空配列で明示的に送る。フィールドを省くと
+    # 既存の設定が残るため、消したい場合は空で上書きするしかない。学生リポジトリ
+    # の main をレビューなしでマージできる主体は作らない、という状態へ毎回収束
+    # させる意図なので、簡略化して省かないこと。
     local protection_config='{
         "required_status_checks": {
             "strict": false,
@@ -237,6 +242,11 @@ setup_protection() {
             "dismissal_restrictions": {
                 "users": [],
                 "teams": []
+            },
+            "bypass_pull_request_allowances": {
+                "users": [],
+                "teams": [],
+                "apps": []
             }
         },
         "enforce_admins": false,


### PR DESCRIPTION
## 概要

`scripts/setup-branch-protection.sh` から 2 つの不要な要素を取り除く。

```diff
             "dismissal_restrictions": {
                 "users": [],
                 "teams": []
-            },
-            "bypass_pull_request_allowances": {
-                "users": [],
-                "teams": [],
-                "apps": ["github-actions"]
             }
         },
-        "enforce_admins": true,
+        "enforce_admins": false,
```

あわせて `setup_enforce_admins()` 関数（37 行）とその呼び出しを削除した。

Resolves #577

## issue の前提を 1 点訂正した

issue には「API が受け付けていない」と書いたが、**手元で試すと受理される**。私の PAT で同じペイロードを送ると bypass は正しく設定された。

```
=== スクリプトと同一のペイロードで PUT ===
bypass_apps=1 enforce_admins=true checks=0
```

一方、実際の学生リポジトリでは他のフィールドがすべてスクリプトの設定と一致しているのに bypass だけが欠けている。

```
k24rs023-ise-report1: dismiss=true bypass=null checks=あり
k24rs124-ise-report1: dismiss=true bypass=null checks=あり
k26gjk01-fit2026:     dismiss=true bypass=null checks=あり
k25gjk04-latex:       dismiss=true bypass=null checks=あり

スクリプトの設定値: dismiss=true / bypass=あり / checks=あり
```

差は**実行主体**と見られる。スクリプトは workflow 内で App token で動き、私の検証は PAT だった。App token では他の App へのバイパス付与が黙って落ちる、という筋が最も自然である。

いずれにせよ**「設定しているつもりで効いていない」状態**であり、削除する理由は変わらない。

## 削除の根拠

**bypass は用途が無い。** `main` へ push する workflow も `gh pr merge` する workflow も存在しない。

| workflow | push 先 |
|---|---|
| `create-next-draft.yml` | `NEXT_BRANCH`（`*-draft` / `abstract-*`） |
| `sync-next-draft.yml` | `$into`（後続の draft ブランチ） |
| `auto-final-merge.yml` | push もマージもしない（`gh pr create` のみ） |

ブランチ保護の対象は `main` のみなので、draft ブランチへの push は保護に触れない。`auto-final-merge.yml` が実際にマージしていた頃（`64c9f2b` 以前）の名残である。

## enforce_admins の二重設定

スクリプトは JSON で `true` にした直後、別エンドポイントで `false` に上書きしていた。コメントは API の制約を理由に挙げている。

```bash
# GitHub API では enforce_admins は別エンドポイントで設定する必要がある
```

**これは誤りだった。** 教員のテストリポジトリ（`k19rs999-sotsuron`）で両方向を実測した。

```
=== 検証1: JSON で enforce_admins: true を渡す ===
enforce_admins=true
=== 検証2: JSON で enforce_admins: false に戻す ===
enforce_admins=false
```

`#392`（"Fix enforce_admins setting using correct GitHub API endpoint"）が対処した症状は、おそらく **JSON が `true` を要求しているのに意図は `false` だった**ことによる。API の制約ではなく設定値の不一致だったと考えられる。

JSON を `false` にすれば 1 回の API 呼び出しで済み、関数ごと不要になる。

## 検証

`k19rs999-sotsuron` で以下を実施し、**退避した状態に完全復元**した。

1. 保護設定を退避
2. JSON で `enforce_admins` を true → false と往復
3. スクリプトと同一のペイロードで PUT し、bypass が設定されることを確認
4. `setup_enforce_admins` 相当の DELETE を実行し、bypass が消えないことを確認
5. 退避内容から復元

復元時に気付いた点として、**`bypass_pull_request_allowances` はフィールドを省いただけでは消えない**。明示的に空配列で送る必要がある。既に bypass が付いているリポジトリは、本 PR のスクリプトを再実行しても消えない（該当は無い見込みだが、必要なら別途対応する）。

`shellcheck` の指摘件数は変更前後で同一（4 件）。いずれも `SC2155` で、本 PR が触っていない箇所の既存指摘である。

## README

`setup-branch-protection.sh` の機能説明を実態に合わせた。

```diff
-  - GitHub Actions によるレビュー要件のバイパスを許可
+  - 管理者は保護を回避可能（`enforce_admins: false`。教員の緊急対応用）
```

smkwlab/latex-ecosystem#158 の対応（#576）でこの行を「レビュー要件のバイパスを許可」に書き直したが、その設定自体を今回消すため、実際に効いている `enforce_admins` の説明に置き換えた。
