### PR TITLE
fix(create-repo): drop renovate.json from generated student repositories

### DIFF
--- a/create-repo/common-lib.sh
+++ b/create-repo/common-lib.sh
@@ -719,8 +719,12 @@ cleanup_template_files() {
     # ブランチから持ち込む。Renovate App が学生リポジトリに入っていないので現状は何も
     # 起きないが、それは App のインストール範囲というコード管理外の設定に安全性を
     # 預けている状態であり、範囲が広がれば全学生リポジトリで動き出す。
+    #
+    # 配置場所はエコシステムが実際に配る 2 つに限る。Renovate はほかにも
+    # .renovaterc / package.json の renovate フィールドなどを読むが、それらを
+    # 学生リポジトリへ持ち込む経路は無い。増やすなら、まず配る側を見直すこと。
     rm -f .github/dependabot.yml 2>/dev/null || true
-    rm -f .github/renovate.json 2>/dev/null || true
+    rm -f .github/renovate.json renovate.json 2>/dev/null || true
     # GitHub は README を .github/ → root → docs/ の順に探して最初の 1 つを表示する。
     # テンプレート側はこの性質を使い、テンプレートの使い方を .github/README.md に、
     # 学生が記入する著者情報を root の README.md に置いている。ここで前者を削除する

--- a/create-repo/common-lib.sh
+++ b/create-repo/common-lib.sh
@@ -711,10 +711,16 @@ cleanup_template_files() {
     rm -f CLAUDE.md 2>/dev/null || true
     rm -rf docs/ 2>/dev/null || true
     find . -name '*-aldc' -exec rm -rf {} + 2>/dev/null || true
-    # 学生リポジトリでは Actions の自動更新は不要（最新化はテンプレート側の dependabot
-    # で管理）。誤マージ防止 CI（prevent-draft-merge）や review 必須保護と dependabot PR
-    # が干渉して溜まるため、生成時に削除する（#514）。
+    # 学生リポジトリでは依存の自動更新は不要（最新化はテンプレート側で管理）。誤マージ
+    # 防止 CI（prevent-draft-merge）や review 必須保護と bot の PR が干渉して溜まるため、
+    # 生成時に削除する（#514）。
+    #
+    # renovate.json も同じ理由で消す。こちらは aldc が latex-environment の release
+    # ブランチから持ち込む。Renovate App が学生リポジトリに入っていないので現状は何も
+    # 起きないが、それは App のインストール範囲というコード管理外の設定に安全性を
+    # 預けている状態であり、範囲が広がれば全学生リポジトリで動き出す。
     rm -f .github/dependabot.yml 2>/dev/null || true
+    rm -f .github/renovate.json 2>/dev/null || true
     # GitHub は README を .github/ → root → docs/ の順に探して最初の 1 つを表示する。
     # テンプレート側はこの性質を使い、テンプレートの使い方を .github/README.md に、
     # 学生が記入する著者情報を root の README.md に置いている。ここで前者を削除する


### PR DESCRIPTION
## 背景

エコシステムの依存管理を Renovate に一本化した（smkwlab/latex-ecosystem#159）。テンプレート 6 リポジトリの `dependabot.yml` は `renovate.json` に置き換わっている。

学生リポジトリには `.github/renovate.json` が**既に入っている**。出所はテンプレートではなく **aldc** で、`latex-environment` の release ブランチが `.github/renovate.json` を含み、devcontainer と一緒に注入される（例: `k25gjk01-iot74`、2026-06-19 の「add LaTeX environment」commit）。

現状これで問題は起きていない。学生リポジトリでの Renovate PR は 0 件、`renovate/` ブランチも 0 件で、Renovate App が入っていないためである。

**ただしその無害さは App のインストール範囲というコード管理外の設定に依存している。** 誰かが App を org 全体へ広げた瞬間、全学生リポジトリで Renovate が動き出し、#514 で `dependabot.yml` について経験したのと同じこと（誤マージ防止 CI や review 必須保護と bot の PR が干渉して溜まる。学生から見れば身に覚えのない PR が現れ、承認が要るので自分では閉じられない）が起きる。

安全性を設定に預けない。`dependabot.yml` と同じ扱いにする。

## 変更内容

`cleanup_template_files()` で `.github/renovate.json` も削除する。この関数は aldc 実行の後に呼ばれるため、aldc が持ち込んだファイルを確実に消せる。

あわせて既存コメントの「最新化はテンプレート側の **dependabot** で管理」という記述を直した。テンプレートは Renovate に移行したのでツール名を書かない形にしている。

## 対象外

**既存の学生リポジトリに残っている `renovate.json` はこの PR では消さない。** `scripts/remove-dependabot-config.sh` に相当する一括削除が要るが、学生リポジトリの内容を書き換える破壊的操作なので、実施するかどうかは別に判断したい。現状は無害（App 未導入）なので緊急性は無い。

ref: smkwlab/latex-ecosystem#159
